### PR TITLE
Add CI to build and deploy site using github actions

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,4 +1,4 @@
-name: Build Site
+name: Build & Deploy Site
 
 on: push
 
@@ -22,3 +22,11 @@ jobs:
       env:
         SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
         ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
+
+    - name: Deploy
+      uses: s0/git-publish-subdir-action@master
+      env:
+        REPO: git@github.com:reach4help/reach4help-gh-pages.git
+        BRANCH: gh-pages
+        FOLDER: site/public
+        SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_KEY_SITE }}

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -3,7 +3,7 @@ name: Build & Deploy Site
 on: push
 
 jobs:
-  deploy-to-ghe:
+  deploy-to-gh-pages:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -23,6 +23,10 @@ jobs:
         SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
         ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
 
+    - name: Copy CNAME
+      run: |
+        cp site/CNAME site/public/CNAME
+
     - name: Deploy
       uses: s0/git-publish-subdir-action@master
       env:

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,0 +1,24 @@
+name: Build Site
+
+on: push
+
+jobs:
+  deploy-to-ghe:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+
+    - name: Install Packages
+      run: yarn install
+
+    - name: Build Site
+      run: cd site && yarn run build
+      env:
+        SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+        ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,6 +1,9 @@
 name: Build & Deploy Site
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   deploy-to-gh-pages:

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+reach4help.org


### PR DESCRIPTION
gh-pages works well as a CDN, and actions provides good transparency into the build process.

After having thought it over somewhat, and having done this with a number of other production sites, I feel it's best for our landing page too, as it keeps everything in one system (GitHub) and avoids the need to manage users/admins in multiple places.

This deploys the site by pushing it to the `gh-pages` branch of https://github.com/reach4help/reach4help-gh-pages

Example of what a build log looks like: https://github.com/reach4help/reach4help/actions/runs/61003644