### PR TITLE
improvement(map-ux): don't zoom on clusters, update right hand list

### DIFF
--- a/map/src/App.tsx
+++ b/map/src/App.tsx
@@ -44,7 +44,7 @@ class App extends React.Component<Props, State> {
   };
 
   private setResults = (results: MarkerInfo[]) => {
-    this.setState({ results });
+    this.setState({ results, selectedResult: null });
   };
 
   private setUpdateResultsCallback = (callback: (() => void) | null) => {

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -234,14 +234,13 @@ class MapComponent extends React.Component<Props, {}> {
     });
 
     markerClusterer.addListener('click', (cluster: MarkerClusterer) => {
-      // Store the next results in the state
-      const nextResults = {
+      // Immidiately change the result list to the cluster instead
+      // Don't update nextResults as we want that to still be for the current
+      // viewport
+      this.updateResultsTo({
         markers: cluster.getMarkers(),
         results: cluster.getMarkers().map(marker => getInfo(marker)),
-      };
-      const { setNextResults: updateNextResults } = this.props;
-      updateNextResults(nextResults);
-      this.updateResults();
+      });
     });
 
     // The clusters have been computed so we can
@@ -307,18 +306,25 @@ class MapComponent extends React.Component<Props, {}> {
   };
 
   private updateResults = () => {
-    const { results, nextResults, setResults: updateResults } = this.props;
+    const { results, nextResults } = this.props;
     if (this.map && nextResults && results !== nextResults.results) {
+      this.updateResultsTo(nextResults);
+    }
+  };
+
+  private updateResultsTo = (results: NextResults) => {
+    const { setResults } = this.props;
+    if (this.map) {
       // Clear all existing marker labels
       for (const marker of this.map.markers.values()) {
         marker.setLabel('');
       }
       // Relabel marker labels based on theri index
-      nextResults.markers.forEach((marker, index) => {
+      results.markers.forEach((marker, index) => {
         marker.setLabel((index + 1).toString());
       });
       // Update the new results state
-      updateResults(nextResults.results);
+      setResults(results.results);
     }
   };
 

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -139,6 +139,7 @@ class MapComponent extends React.Component<Props, {}> {
         imagePath:
           'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m',
         ignoreHidden: true,
+        zoomOnClick: false,
         averageCenter: true,
         gridSize: 30,
       },
@@ -230,6 +231,17 @@ class MapComponent extends React.Component<Props, {}> {
         });
       }
       // $("#visible-markers").html('<h2>Loading List View ... </h2>');
+    });
+
+    markerClusterer.addListener('click', (cluster: MarkerClusterer) => {
+      // Store the next results in the state
+      const nextResults = {
+        markers: cluster.getMarkers(),
+        results: cluster.getMarkers().map(marker => getInfo(marker)),
+      };
+      const { setNextResults: updateNextResults } = this.props;
+      updateNextResults(nextResults);
+      this.updateResults();
     });
 
     // The clusters have been computed so we can


### PR DESCRIPTION
### Motivation: 

Too much zooming makes for bad experience

### Changes:

Clicking a cluster now only updates the right hand list view

![Kapture 2020-03-24 at 16 35 44](https://user-images.githubusercontent.com/961844/77486717-afa93480-6ded-11ea-8e86-85361c47ea9b.gif)
