### PR TITLE
docs: change contrib guidelines for security issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,8 @@ So to read the specific guidelines for each project please refer to:
 
 # How to report a bug
 
-> If you find a security vulnerability, open an issue describing the problem.
+> If you find a security vulnerability, please contact us directly at `security@reach4help.org`.
+> For any other non security-related issues, open an issue describing the problem.
 
 # How to suggest a feature or enhancement
 

--- a/api/CONTRIBUTING.md
+++ b/api/CONTRIBUTING.md
@@ -73,7 +73,8 @@ yarn typeorm migration:run
 
 # How to suggest a feature or enhancement
 
-> Open an issue using with the suggestion you wish to give.
+> If you find a security vulnerability, please contact us directly at `security@reach4help.org`.
+> For any other non security-related issues, open an issue describing the problem.
 
 # Code review process
 

--- a/site/CONTRIBUTING.md
+++ b/site/CONTRIBUTING.md
@@ -54,9 +54,8 @@ gatsby develop
 
 # How to report a bug
 
-> If you find a security vulnerability, do NOT open an issue. Email <email> instead.
-
-> Open an issue using the BUG template provided.
+> If you find a security vulnerability, please contact us directly at `security@reach4help.org`.
+> For any other non security-related issues, open an issue describing the problem.
 
 # How to suggest a feature or enhancement
 

--- a/web-client/CONTRIBUTING.md
+++ b/web-client/CONTRIBUTING.md
@@ -67,7 +67,8 @@ cd ./web-client && yarn start
 
 # How to report a bug
 
-> If you find a security vulnerability, open an issue describing the problem.
+> If you find a security vulnerability, please contact us directly at `security@reach4help.org`.
+> For any other non security-related issues, open an issue describing the problem.
 
 # How to suggest a feature or enhancement
 


### PR DESCRIPTION
This PR modifies the contributor guidelines so that people report security issues by mail and other issues via the github issue tracker.

Fixes #109 