### PR TITLE
Use Heroku Release event to run post install actions

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: yarn workspace api run heroku-postbuild
+release: yarn typeorm migration:run -f api/dist/database/ormconfig.js
 web: yarn workspace api start:prod

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: yarn workspace api run heroku-postbuild
 web: yarn workspace api start:prod

--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "pre-commit": "lint-staged",
-    "heroku-postbuild": "nest build && yarn typeorm migration:run -f dist/database/ormconfig.js"
+    "heroku-postbuild": "nest build"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
### Motivation

We want to only build the app once when we merge to `master`. From there on we will promote the app through the pipeline. In order for this to work, we need to use the `release` even to trigger migrations as code moves through the pipe.

### Changes

Removed migration execution from `heroku-postbuild` in `api/package.json` and moved it to `release` in the root level `Procfile`

### Linked Issues

closes #125 