### PR TITLE
fix: installed cross-env and changed start script

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -29,7 +29,7 @@
     "yup": "^0.28.3"
   },
   "scripts": {
-    "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
+    "start": "cross-env SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
@@ -67,6 +67,7 @@
     "@types/yup": "^0.26.33",
     "@typescript-eslint/eslint-plugin": "^2.24.0",
     "@typescript-eslint/parser": "^2.24.0",
+    "cross-env": "^7.0.2",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-import-resolver-typescript": "^2.0.0",


### PR DESCRIPTION
I can change to `bash` but could this be something that would be an unnecessary barrier to newcomers? 