### PR TITLE
Center text inside sections

### DIFF
--- a/site/src/components/Section.js
+++ b/site/src/components/Section.js
@@ -9,7 +9,7 @@ import LinkAnimated from './LinkAnimated';
 const SectionContainer = styled.div`
   min-height: 100vh;
   min-width: 320px;
-  max-width: 1366px;
+  max-width: 1100px;
   display: flex;
   margin: auto;
   flex: 0 1 auto;

--- a/site/src/sections/Resources.js
+++ b/site/src/sections/Resources.js
@@ -47,7 +47,7 @@ const Resources = () => (
       `}
       render={data => {
         return (
-          <Flex alignItems="center" flexWrap="wrap">
+          <Flex justifyContent="center" alignItems="center" flexWrap="wrap">
             <Box width={[1, 1, 4 / 6]} px={[1, 2, 4]}>
               <Fade bottom>
                 <ReactMarkdown

--- a/site/src/sections/Team.js
+++ b/site/src/sections/Team.js
@@ -49,7 +49,7 @@ const Resources = () => (
       `}
       render={data => {
         return (
-          <Flex alignItems="center" flexWrap="wrap">
+          <Flex justifyContent="center" alignItems="center" flexWrap="wrap">
             <Box width={[1, 1, 4 / 6]} px={[1, 2, 4]}>
               <Fade bottom>
                 <ReactMarkdown


### PR DESCRIPTION
Description
-----------
Center the text inside sections.

Motivation
----------
In the current deployed site not all text is centered and can feel a bit strange to read the site.

Live preview: https://deploy-preview-191--reach4help.netlify.com/
