### PR TITLE
Rename "application security" team to "security"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ This PR creates, modifies, or deletes:
 
 <!--
 
-If you checked any of those, please request a review from `@reach4help/application-security`.
+If you checked any of those, please request a review from `@reach4help/security`.
 
 -->
 

--- a/docs/TEAMS.md
+++ b/docs/TEAMS.md
@@ -68,7 +68,7 @@ please read our [Getting Involved / Onboarding](GETTING_INVOLVED.md) document.
 | **@Miranda**             |                                                        | **Lead**        | UTC+0 (+1)     |
 | You?                 |                                                        |             |                |
 
-### Application Security (`#team-security`)
+### Security (`#team-security`)
 
 | Slack                | GitHub Handle                                          | Role     | Timezone (DST) |
 |----------------------|--------------------------------------------------------|----------|----------------|


### PR DESCRIPTION
Description
-----------
Rename "Application Security" team to "Security".
Once this is merged, I'll make the change effective in the GitHub org.

Motivation
----------
The tasks handled by people in the team also include things like network security and compliance, it makes more sense to rename it that way imo. Also for consistency, as the slack team and channel have that same name and it triggers me 😂.

Testing Guidelines
------------------

Release Checklist
-----------------

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

Security Checklist
-------------------

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/application-security`.

-->

Additional Notes
----------------

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

-->
