### PR TITLE
Disable eslint anchor-is-valid for verification code page

### DIFF
--- a/web-client/src/components/VerificationCode/VerificationCode.tsx
+++ b/web-client/src/components/VerificationCode/VerificationCode.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import { Button, Form, Input, Typography } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';


### PR DESCRIPTION
Description
-----------

Disable eslint rule anchor-is-valid for verification code page.

Motivation
----------

Verification code page  has an placeholder link and eslint is giving linting errors because of that.

Testing Guidelines
------------------

Release Checklist
-----------------

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

Security Checklist
-------------------

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

Additional Notes
----------------

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

-->
