### PR TITLE
docs(pr): add line to add screenshot if the pr changes visual

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,4 +38,6 @@ Additional Notes
 
 If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.
 
+If this PR adds or changes visual, please add a screenshot of the changes.
+
 -->


### PR DESCRIPTION
Description
-----------

 Add a new line to the PR template to add a screenshot of the changes when the changes are visual.

Motivation
----------

When the changes are visual it's easier for the reviewers to also see a screenshot of the changes
