### PR TITLE
fix for removing scrolling from cards, while remaining with card centred

### DIFF
--- a/web-client/src/components/CenteredCard/CenteredCard.tsx
+++ b/web-client/src/components/CenteredCard/CenteredCard.tsx
@@ -1,20 +1,9 @@
 import { Card } from 'antd';
 import React from 'react';
-import styled from 'styled-components';
-
-const StyledCard = styled(Card)`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  min-width: 70vw;
-  height: 70vh;
-  overflow-y: scroll;
-`;
 
 const CenteredCard: React.FC<CenteredScreenProps> = ({
   children,
-}): React.ReactElement => <StyledCard>{children}</StyledCard>;
+}): React.ReactElement => <Card>{children}</Card>;
 
 interface CenteredScreenProps {
   children: React.ReactNode;

--- a/web-client/src/components/GradientBackground/GradientBackground.tsx
+++ b/web-client/src/components/GradientBackground/GradientBackground.tsx
@@ -5,8 +5,12 @@ import { COLORS } from '../../theme/colors';
 
 const Background = styled.div`
   min-height: 100vh;
-  height: 100%;
-  width: 100%;
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 15px;
   background: ${COLORS.backgroundAlternative};
   background: linear-gradient(
     125.44deg,

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1,1 +1,17 @@
 @import '~antd/dist/antd.css';
+
+@media (max-width: 667px) and (orientation: portrait) {
+  .ant-card {
+    min-width: 100%;
+    /* background: transparent !important; */
+  }
+  /* .ant-card-bordered {
+    border: none !important;
+  } */
+}
+
+@media (min-width: 1024px) and (orientation: landscape) {
+  .ant-card {
+    min-width: 50%;
+  }
+}


### PR DESCRIPTION
## Description
fix for removing scrolling from cards, while remaining with card centred both on mobile and desktop. Leave commented CSS in case we want to make the cards transparent in the future for mobile layout.

## Motivation

## Testing Guidelines

## Release Checklist

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->

Closes: #371
