### PR TITLE
When a user is created add the JWT claim for `pin: true`

### DIFF
--- a/functions/src/questionnaires/functions.ts
+++ b/functions/src/questionnaires/functions.ts
@@ -1,0 +1,69 @@
+import { DocumentSnapshot } from 'firebase-functions/lib/providers/firestore';
+import { EventContext } from 'firebase-functions/lib/cloud-functions';
+import * as admin from 'firebase-admin';
+import { IQuestionnaire, Questionnaire, QuestionnaireType } from '../models/questionnaires';
+import { validateOrReject } from 'class-validator';
+import { setIsUserCav, setIsUserPin } from '../users/functions';
+
+const db = admin.firestore();
+
+export const validateQuestionnaire = (value: IQuestionnaire): Promise<void> => {
+  return validateOrReject(Questionnaire.factory(value)).then(() => {
+    return Promise.resolve();
+  });
+};
+
+export const updateUserQuestionnaireRef = (snapshot: DocumentSnapshot, userId: string | undefined, claims: { pin?: boolean; cav?: boolean } | undefined): Promise<void> => {
+    const questionnaire = Questionnaire.factory(snapshot.data() as IQuestionnaire);
+
+    // Only my questionnaires count and only if I am logged in for my own requests.
+    if (!userId || questionnaire.parentRef.id !== userId) {
+      return Promise.resolve();
+    }
+
+    const userRef = db.collection('users').doc(userId);
+    const operations: Promise<void>[] = [];
+
+    switch (questionnaire.type) {
+      case QuestionnaireType.pin:
+        operations.push(userRef
+          .update({ pinQuestionnaireRef: snapshot.ref })
+          .then());
+        if (!claims?.pin) {
+          // If I wasn't a PIN before... I am now
+          operations.push(setIsUserPin(userId, true));
+        }
+        break;
+      case QuestionnaireType.cav:
+        operations.push(userRef
+          .update({ cavQuestionnaireRef: snapshot.ref })
+          .then());
+        if (!claims?.cav) {
+          // If I wasn't a CAV before... I am now
+          operations.push(setIsUserCav(userId, true));
+        }
+        break;
+      default:
+        break;
+    }
+
+    return Promise.all(operations).then();
+  }
+;
+
+export const onCreate = (snapshot: DocumentSnapshot, context: EventContext) => {
+  return validateQuestionnaire(snapshot.data() as IQuestionnaire)
+    .then(() => {
+      const operations: Promise<void>[] = [
+        updateUserQuestionnaireRef(snapshot, context.auth?.uid, context.auth?.token),
+      ];
+      return Promise.all(operations);
+    })
+    .catch(errors => {
+      console.error('Invalid Questionnaire Found: ', errors);
+      return db
+        .collection('questionnaires')
+        .doc(context.params.questionnaireId)
+        .delete();
+    });
+};

--- a/functions/src/questionnaires/index.ts
+++ b/functions/src/questionnaires/index.ts
@@ -1,0 +1,6 @@
+import * as functions from 'firebase-functions';
+import { onCreate } from './functions';
+
+export const triggerEventsWhenQuestionnaireIsCreated = functions.firestore
+  .document('questionnaires/{questionnaireId}')
+  .onCreate(onCreate);

--- a/functions/src/users/functions.ts
+++ b/functions/src/users/functions.ts
@@ -25,7 +25,7 @@ export const setIsUserCav = (userId: string, status: boolean): Promise<void> => 
 export const onCreate = (snapshot: DocumentSnapshot, context: EventContext) => {
   return validateUser(snapshot.data() as IUser)
     .then(() => {
-      const operations = [setIsUserPin(snapshot.id, true)];
+      const operations: Promise<void>[] = [];
       return Promise.all(operations);
     })
     .catch(errors => {

--- a/functions/src/users/functions.ts
+++ b/functions/src/users/functions.ts
@@ -6,15 +6,28 @@ import * as admin from 'firebase-admin';
 
 admin.initializeApp();
 const db = admin.firestore();
+const auth = admin.auth();
 
-const validateUser = (value: IUser): Promise<void> => {
+export const validateUser = (value: IUser): Promise<void> => {
   return validateOrReject(User.factory(value)).then(() => {
     return Promise.resolve();
   });
 };
 
+export const setIsUserPin = (userId: string, status: boolean): Promise<void> => {
+  return auth.setCustomUserClaims(userId, { pin: status });
+};
+
+export const setIsUserCav = (userId: string, status: boolean): Promise<void> => {
+  return auth.setCustomUserClaims(userId, { cav: status });
+};
+
 export const onCreate = (snapshot: DocumentSnapshot, context: EventContext) => {
   return validateUser(snapshot.data() as IUser)
+    .then(() => {
+      const operations = [setIsUserPin(snapshot.id, true)];
+      return Promise.all(operations);
+    })
     .catch(errors => {
       console.error('Invalid User Found: ', errors);
       return db

--- a/functions/src/users/index.ts
+++ b/functions/src/users/index.ts
@@ -1,17 +1,9 @@
 import * as functions from 'firebase-functions';
 
-import { onCreate, setIsUserPin } from './functions';
+import { onCreate } from './functions';
 
 export const triggerEventsWhenUserIsCreated = functions.firestore
   .document('users/{userId}')
   .onCreate(onCreate);
-
-export const callableSetUserPinClaim = functions.https.onCall((data: { status: boolean }, context) => {
-  return context.auth?.uid ? setIsUserPin(context.auth.uid, data.status || false) : Promise.reject(new Error('Unauthorized'));
-});
-
-export const callableSetUserCavClaim = functions.https.onCall((data: { status: boolean }, context) => {
-  return context.auth?.uid ? setIsUserPin(context.auth.uid, data.status || false) : Promise.reject(new Error('Unauthorized'));
-});
 
 export * from './privilegedInformation';

--- a/functions/src/users/index.ts
+++ b/functions/src/users/index.ts
@@ -1,9 +1,17 @@
 import * as functions from 'firebase-functions';
 
-import { onCreate } from './functions';
+import { onCreate, setIsUserPin } from './functions';
 
 export const triggerEventsWhenUserIsCreated = functions.firestore
   .document('users/{userId}')
   .onCreate(onCreate);
+
+export const callableSetUserPinClaim = functions.https.onCall((data: { status: boolean }, context) => {
+  return context.auth?.uid ? setIsUserPin(context.auth.uid, data.status || false) : Promise.reject(new Error('Unauthorized'));
+});
+
+export const callableSetUserCavClaim = functions.https.onCall((data: { status: boolean }, context) => {
+  return context.auth?.uid ? setIsUserPin(context.auth.uid, data.status || false) : Promise.reject(new Error('Unauthorized'));
+});
 
 export * from './privilegedInformation';


### PR DESCRIPTION
## Description

When a user completes a questionnaire (whatever that may be) they are automatically granted the correct PIN or CAV access based on the questionnaire.

## Motivation

## Testing Guidelines

## Release Checklist

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
