### PR TITLE
feat(backend): allow anyone to add markers to datastore

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,5 +1,17 @@
 rules_version = '2';
 
+function verifyMarkerDataComplete(data) {
+   return ('contentTitle' in data) &&
+          ('type' in data) &&
+          ('type' in data.type) &&
+          ('contact' in data) &&
+          ('loc' in data) &&
+          ('description' in data.loc) &&
+          ('lat' in data.loc) &&
+          ('lng' in data.loc) &&
+          ('serviceRadius' in data.loc)
+}
+
 function isAuthenticated() {
   return request.auth.uid != null;
 }
@@ -124,6 +136,14 @@ service cloud.firestore {
     // Catch all -- Dont read/write to collections without rules
     match /{document=**} {
       allow read, write: if false;
+    }
+
+    match /markers/{markerID} {
+      // Anyone can read any marker
+      allow read: if true;
+      // Any one can add a marker (but not edit it)
+      allow write: if verifyMarkerDataComplete(request.resource.data) &&
+       !exists(/databases/$(database)/documents/markers/$(request.resource.id));
     }
 
     match /users/{userID} {

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,14 +1,14 @@
 rules_version = '2';
 
 function verifyMarkerDataComplete(data) {
-   return ('contentTitle' in data) &&
+   return data.visible == false &&
+          ('contentTitle' in data) &&
           ('type' in data) &&
           ('type' in data.type) &&
           ('contact' in data) &&
           ('loc' in data) &&
           ('description' in data.loc) &&
-          ('lat' in data.loc) &&
-          ('lng' in data.loc) &&
+          verifyLatLngObject(data.loc.latLng) &&
           ('serviceRadius' in data.loc)
 }
 


### PR DESCRIPTION
## Description

Ahead of #406

Allows anyone to write to create new markers (not edit existing ones), that save directly to the firestore database.

## Motivation

To be able to accept user data using the new form, allowing users to write directly to the firestore when creating new markers seemed like the best response.

This data isn't currently being used / loaded in the frontend. After this gets in and the initial form gets deployed, I'm going to add a new boolean property called `visible` that (can't be true when users submit) that will be indexed on, to allow users to query for the visible markers only. Marker submissions will then (for now) require a review by someone with appropriate access (currently only admins).

Beyond this I plan on allowing users to optionally view "hidden" fields before adding new information so that they can ensure they're not causing duplicate information.

Also, I want to create a function that runs whenever a marker's data is updated to keep a log of a marker's history.

cc @sabind @lenjoseph thoughts?

## Testing Guidelines

## Release Checklist

- [ ] This code has unit tests
- [x] I have a plan to verify that these changes are working as expected after deploy
- [x] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

cc @reach4help/security

## Additional Notes

We probably want to have unit tests for these rules too, but I was unable to really make progress as the tests aren't currently working locally for me (we should also update the workflows to make sure that they run in CI too, and don't become broken).