### PR TITLE
chore(backend): update scripts to use reach4help as prod env

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "firebase": "firebase",
     "deploy:dev": "yarn workspaces run build && firebase deploy -P reach4help-dev",
     "deploy:staging": "yarn workspaces run build && firebase deploy -P reach4help-staging",
-    "deploy:prod": "yarn workspaces run build && firebase deploy -P reach4help-34372",
+    "deploy:prod": "yarn workspaces run build && firebase deploy -P reach4help",
     "lint": "yarn workspaces run lint",
     "lint:fix": "yarn workspaces run lint:fix",
     "heroku-postbuild": "yarn workspace api run heroku-postbuild"


### PR DESCRIPTION
## Description

We already had the `reach4help` GCP project, it just wasn't set up as a firebase project. I have done this now, and we should phase-out / delete the other production project.

## Motivation

This will lead to nicer URLs etc in our environment variables / project configurations etc...

