### PR TITLE
feat(map): display firebase markers on map

### DIFF
--- a/map/.eslintrc.js
+++ b/map/.eslintrc.js
@@ -25,5 +25,6 @@ module.exports = {
      * Conflicts with prettier indentation for jsx attributes on own line
      */
     'react/jsx-indent': 'off',
+    'react/display-name': 'off',
   },
 };

--- a/map/src/App.tsx
+++ b/map/src/App.tsx
@@ -8,11 +8,10 @@ import { AppContext } from './components/context';
 import { FilterMutator } from './components/filters';
 import Footer from './components/footer';
 import Header from './components/header';
-import Map, { NextResults } from './components/map';
+import Map, { MarkerIdAndInfo } from './components/map';
 import MapLoader from './components/map-loader';
 import Results from './components/results';
 import { Filter } from './data';
-import { MarkerInfo } from './data/markers';
 import styled, {
   CLS_SCREEN_LG_HIDE,
   CLS_SCREEN_LG_ONLY,
@@ -26,9 +25,9 @@ interface Props {
 
 interface State {
   filter: Filter;
-  results: MarkerInfo[] | null;
-  nextResults?: NextResults;
-  selectedResult: MarkerInfo | null;
+  results: MarkerIdAndInfo[] | null;
+  nextResults?: MarkerIdAndInfo[];
+  selectedResult: MarkerIdAndInfo | null;
   updateResultsCallback: (() => void) | null;
   fullScreen: boolean;
   updateResultsOnNextClustering: boolean;
@@ -62,7 +61,7 @@ class App extends React.Component<Props, State> {
     this.setState(state => ({ filter: mutator(state.filter) }));
   };
 
-  private setResults = (results: MarkerInfo[]) => {
+  private setResults = (results: MarkerIdAndInfo[]) => {
     this.setState({ results, selectedResult: null });
   };
 
@@ -70,7 +69,7 @@ class App extends React.Component<Props, State> {
     this.setState({ updateResultsCallback: callback });
   };
 
-  private setSelectedResult = (selectedResult: MarkerInfo | null) => {
+  private setSelectedResult = (selectedResult: MarkerIdAndInfo | null) => {
     this.setState(state => {
       let { resultsMode } = state;
       if (selectedResult && state.resultsMode === 'closed') {
@@ -83,7 +82,7 @@ class App extends React.Component<Props, State> {
     });
   };
 
-  private setNextResults = (nextResults: NextResults) => {
+  private setNextResults = (nextResults: MarkerIdAndInfo[]) => {
     this.setState(state =>
       isEqual(state.nextResults, nextResults) ? {} : { nextResults },
     );
@@ -206,7 +205,7 @@ class App extends React.Component<Props, State> {
             <Results
               className="results"
               results={results}
-              nextResults={nextResults?.results || null}
+              nextResults={nextResults}
               selectedResult={selectedResult}
               setSelectedResult={this.setSelectedResult}
               updateResults={this.updateResults}

--- a/map/src/components/add-information.tsx
+++ b/map/src/components/add-information.tsx
@@ -1,4 +1,4 @@
-import firebase from 'firebase';
+import firebase from 'firebase/app';
 import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
 import React from 'react';

--- a/map/src/components/add-information.tsx
+++ b/map/src/components/add-information.tsx
@@ -505,8 +505,8 @@ class AddInstructions extends React.Component<Props, State> {
         for (const type of CONTACT_TYPES) {
           const typeInfo = info.contact?.[type];
           const typeUrls = urls[type] || [];
-          const sectionLabel = (lang: Language) => (
-            <strong>
+          const sectionLabel = (key: number, lang: Language) => (
+            <strong key={key}>
               {t(lang, s => s.addInformation.screen.contactInfo.sections[type])}
             </strong>
           );
@@ -514,7 +514,7 @@ class AddInstructions extends React.Component<Props, State> {
             if (Object.keys(typeInfo).length === 0 && typeUrls.length === 0) {
               validation.errors.push(lang =>
                 t(lang, s => s.addInformation.errors.emptyContactSection, {
-                  section: sectionLabel(lang),
+                  section: key => sectionLabel(key, lang),
                 }),
               );
               validation.invalidInputs.push(type);
@@ -524,7 +524,7 @@ class AddInstructions extends React.Component<Props, State> {
                 if (label === '') {
                   validation.errors.push(lang =>
                     t(lang, s => s.addInformation.errors.urlMissingLabel, {
-                      section: sectionLabel(lang),
+                      section: key => sectionLabel(key, lang),
                     }),
                   );
                   validation.invalidInputs.push(
@@ -533,7 +533,7 @@ class AddInstructions extends React.Component<Props, State> {
                 } else if (url === '') {
                   validation.errors.push(lang =>
                     t(lang, s => s.addInformation.errors.urlMissingURL, {
-                      section: sectionLabel(lang),
+                      section: key => sectionLabel(key, lang),
                     }),
                   );
                   validation.invalidInputs.push(
@@ -567,7 +567,7 @@ class AddInstructions extends React.Component<Props, State> {
                   state: 'error',
                   error: lang =>
                     t(lang, s => s.addInformation.errors.submitError, {
-                      error: <span>{String(error)}</span>,
+                      error: key => <span key={key}>{String(error)}</span>,
                     }),
                 },
               }),
@@ -1070,12 +1070,12 @@ class AddInstructions extends React.Component<Props, State> {
               <div className="screen">
                 <h2>
                   {t(lang, s => s.addInformation.screen.contactInfo.header, {
-                    name: <span>{info.contentTitle}</span>,
+                    name: key => <span key={key}>{info.contentTitle}</span>,
                   })}
                 </h2>
                 <p>
                   {t(lang, s => s.addInformation.screen.contactInfo.info, {
-                    name: <strong>{info.contentTitle}</strong>,
+                    name: key => <strong key={key}>{info.contentTitle}</strong>,
                   })}
                 </p>
                 <form onSubmit={this.completeContactInformation}>

--- a/map/src/components/add-information.tsx
+++ b/map/src/components/add-information.tsx
@@ -19,7 +19,7 @@ import {
   MarkerInfo,
 } from 'src/data/markers';
 import { format, Language, t } from 'src/i18n';
-import { RecursivePartial } from 'src/util';
+import { isDefined, RecursivePartial } from 'src/util';
 
 import {
   isMarkerType,
@@ -179,9 +179,6 @@ const extractContactInputIdData = (target: HTMLElement) => {
 };
 
 type ContactInputIdData = ReturnType<typeof extractContactInputIdData>;
-
-const isDefined = <T extends unknown>(val: T | undefined): val is T =>
-  val !== undefined;
 
 class AddInstructions extends React.Component<Props, State> {
   private markerInfo: MarkerInputInfo | null = null;

--- a/map/src/components/footer.tsx
+++ b/map/src/components/footer.tsx
@@ -26,8 +26,8 @@ const Footer = () => (
       <FooterWrapper>
         <div className="grow">
           {t(lang, s => s.footer.netlifyNote, {
-            link: (
-              <a href="https://www.netlify.com/">
+            link: key => (
+              <a key={key} href="https://www.netlify.com/">
                 {t(lang, s => s.footer.netlifyLinkText)}
               </a>
             ),

--- a/map/src/components/footer.tsx
+++ b/map/src/components/footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as firebase from 'src/data/firebase';
 import { t } from 'src/i18n';
 
 import styled from '../styling';
@@ -15,36 +16,83 @@ const FooterWrapper = styled.footer`
     flex-grow: 1;
   }
 
-  > a {
+  > a,
+  > button {
     margin-left: ${p => p.theme.spacingPx}px;
+    color: ${p => p.theme.textLinkColor};
+    background: none;
+    border: none;
+    outline: none;
+    cursor: pointer;
+
+    &: hover {
+      color: ${p => p.theme.textLinkHoverColor};
+      text-decoration: underline;
+    }
   }
 `;
 
-const Footer = () => (
-  <AppContext.Consumer>
-    {({ lang }) => (
-      <FooterWrapper>
-        <div className="grow">
-          {t(lang, s => s.footer.netlifyNote, {
-            link: key => (
-              <a key={key} href="https://www.netlify.com/">
-                {t(lang, s => s.footer.netlifyLinkText)}
-              </a>
-            ),
-          })}
-          <span aria-label="heart emoji" role="img">
-            &nbsp;❤️
-          </span>
-        </div>
-        <a href="https://github.com/reach4help/reach4help/">
-          {t(lang, s => s.footer.githubRepo)}
-        </a>
-        <a href="https://github.com/reach4help/reach4help/blob/master/CODE_OF_CONDUCT.md">
-          {t(lang, s => s.footer.codeOfConduct)}
-        </a>
-      </FooterWrapper>
-    )}
-  </AppContext.Consumer>
-);
+interface State {
+  includingHidden: boolean;
+}
+
+class Footer extends React.PureComponent<{}, State> {
+  public constructor(props: {}) {
+    super(props);
+    this.state = {
+      includingHidden: firebase.includingHidden(),
+    };
+  }
+
+  public componentDidMount() {
+    firebase.addInformationListener(this.firebaseInformationUpdated);
+  }
+
+  public componentWillUnmount() {
+    firebase.removeInformationListener(this.firebaseInformationUpdated);
+  }
+
+  private firebaseInformationUpdated: firebase.InformationListener = update =>
+    this.setState({ includingHidden: update.includingHidden });
+
+  public render = () => {
+    const { includingHidden } = this.state;
+    return (
+      <AppContext.Consumer>
+        {({ lang }) => (
+          <FooterWrapper>
+            <div className="grow">
+              {t(lang, s => s.footer.netlifyNote, {
+                link: key => (
+                  <a key={key} href="https://www.netlify.com/">
+                    {t(lang, s => s.footer.netlifyLinkText)}
+                  </a>
+                ),
+              })}
+              <span aria-label="heart emoji" role="img">
+                &nbsp;❤️
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => firebase.includeHiddenMarkers(!includingHidden)}
+            >
+              {t(
+                lang,
+                s => s.footer[includingHidden ? 'hideHidden' : 'showHidden'],
+              )}
+            </button>
+            <a href="https://github.com/reach4help/reach4help/">
+              {t(lang, s => s.footer.githubRepo)}
+            </a>
+            <a href="https://github.com/reach4help/reach4help/blob/master/CODE_OF_CONDUCT.md">
+              {t(lang, s => s.footer.codeOfConduct)}
+            </a>
+          </FooterWrapper>
+        )}
+      </AppContext.Consumer>
+    );
+  };
+}
 
 export default Footer;

--- a/map/src/components/header.tsx
+++ b/map/src/components/header.tsx
@@ -54,16 +54,23 @@ const Header = (props: Props) => {
                 <p>{t(lang, s => s.info)}</p>
                 <p className="muted">
                   {t(lang, s => s.about, {
-                    reach4Help: (
-                      <a href="https://reach4help.org">reach4help.org</a>
+                    reach4Help: key => (
+                      <a key={key} href="https://reach4help.org">
+                        reach4help.org
+                      </a>
                     ),
-                    githubSource: (
-                      <a href="https://github.com/reach4help/reach4help/tree/master/map">
+                    githubSource: key => (
+                      <a
+                        key={key}
+                        href="https://github.com/reach4help/reach4help/tree/master/map"
+                      >
                         {t(lang, s => s.githubSourceLabel)}
                       </a>
                     ),
-                    email: (
-                      <a href="mailto:map@reach4help.org">map@reach4help.org</a>
+                    email: key => (
+                      <a key={key} href="mailto:map@reach4help.org">
+                        map@reach4help.org
+                      </a>
                     ),
                   })}
                 </p>

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-icons/md';
 import Search from 'src/components/search';
 import { Filter, MARKER_TYPES } from 'src/data';
+import * as firebase from 'src/data/firebase';
 import { t } from 'src/i18n';
 import { button, iconButton } from 'src/styling/mixins';
 
@@ -110,6 +111,8 @@ class MapComponent extends React.Component<Props, {}> {
   public componentDidMount() {
     const { setUpdateResultsCallback } = this.props;
     setUpdateResultsCallback(this.updateResults);
+    firebase.addInformationListener(this.informationUpdated);
+    firebase.loadInitialData();
   }
 
   public componentDidUpdate(prevProps: Props) {
@@ -133,7 +136,12 @@ class MapComponent extends React.Component<Props, {}> {
   public componentWillUnmount() {
     const { setUpdateResultsCallback } = this.props;
     setUpdateResultsCallback(null);
+    firebase.removeInformationListener(this.informationUpdated);
   }
+
+  private informationUpdated: firebase.InformationListener = () => {
+    // TODO
+  };
 
   private setAddInfoMapClickedListener = (
     listener: ((evt: google.maps.MouseEvent) => void) | null,

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -256,6 +256,7 @@ class MapComponent extends React.Component<Props, {}> {
       for (const [id, marker] of this.map.activeMarkers.firebase.entries()) {
         if (!update.markers.has(id)) {
           removedMarkers.push(marker);
+          this.map.activeMarkers.firebase.delete(id);
         }
       }
       this.map.markerClusterer.removeMarkers(removedMarkers, true);

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -172,6 +172,7 @@ class MapComponent extends React.Component<Props, {}> {
         const visible = !filter.type || info?.info.type.type === filter.type;
         marker.setVisible(visible);
       }
+      this.map.markerClusterer.repaint();
     }
   };
 
@@ -261,7 +262,7 @@ class MapComponent extends React.Component<Props, {}> {
         }
       }
       this.map.markerClusterer.removeMarkers(removedMarkers, true);
-      this.map.markerClusterer.repaint();
+      this.updateMarkersVisibilityUsingFilter(this.map.currentFilter);
     }
   };
 

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -11,6 +11,7 @@ import { Filter, MARKER_TYPES } from 'src/data';
 import * as firebase from 'src/data/firebase';
 import { t } from 'src/i18n';
 import { button, iconButton } from 'src/styling/mixins';
+import { isDefined } from 'src/util';
 
 import { MarkerInfo, MARKERS } from '../data/markers';
 import styled from '../styling';
@@ -24,9 +25,23 @@ import {
 import infoWindowContent from './map-utils/info-window';
 import { debouncedUpdateQueryStringMapLocation } from './map-utils/query-string';
 
+interface MarkerData {
+  hardcoded: Map<string, MarkerInfo>;
+  firebase: Map<string, MarkerInfo>;
+}
+
+type DataSet = keyof MarkerData;
+
+interface ActiveMarkers {
+  /** map from marker index to marker */
+  hardcoded: Map<string, google.maps.Marker>;
+  /** map from firebase id to marker */
+  firebase: Map<string, google.maps.Marker>;
+}
+
 interface MapInfo {
   map: google.maps.Map;
-  markers: Map<MarkerInfo, google.maps.Marker>;
+  activeMarkers: ActiveMarkers;
   markerClusterer: MarkerClusterer;
   /**
    * The filter that is currently being used to display the markers on the map
@@ -46,28 +61,43 @@ interface MapInfo {
       };
 }
 
-const getInfo = (marker: google.maps.Marker): MarkerInfo => marker.get('info');
+const MARKER_DATA_ID = 'id';
 
-const updateMarkersVisibilityUsingFilter = (
-  markers: Map<MarkerInfo, google.maps.Marker>,
-  filter: Filter,
-) => {
-  for (const marker of markers.values()) {
-    const info = getInfo(marker);
-    const visible = !filter.type || info.type.type === filter.type;
-    marker.setVisible(visible);
-  }
-};
+export interface MarkerId {
+  set: DataSet;
+  id: string;
+}
+
+export interface MarkerIdAndInfo {
+  id: MarkerId;
+  info: MarkerInfo;
+}
+
+const getMarkerId = (marker: google.maps.Marker): MarkerId =>
+  marker.get(MARKER_DATA_ID);
+
+// const updateMarkersVisibilityUsingFilter = (
+//   markerData: MarkerData,
+//   markers: ActiveMarkers,
+//   filter: Filter,
+// ) => {
+//   for (const marker of [...markers.hardcoded.values(), ...markers.firebase.values()]) {
+//     const id = getId(marker);
+//     const info = getInfo(marker);
+//     const visible = !filter.type || info.type.type === filter.type;
+//     marker.setVisible(visible);
+//   }
+// };
 
 interface Props {
   className?: string;
   filter: Filter;
-  results: MarkerInfo[] | null;
-  setResults: (results: MarkerInfo[]) => void;
-  nextResults?: NextResults;
-  setNextResults: (nextResults: NextResults) => void;
-  selectedResult: MarkerInfo | null;
-  setSelectedResult: (selectedResult: MarkerInfo | null) => void;
+  results: MarkerIdAndInfo[] | null;
+  setResults: (results: MarkerIdAndInfo[]) => void;
+  nextResults?: MarkerIdAndInfo[];
+  setNextResults: (nextResults: MarkerIdAndInfo[]) => void;
+  selectedResult: MarkerIdAndInfo | null;
+  setSelectedResult: (selectedResult: MarkerIdAndInfo | null) => void;
   /**
    * Call this
    */
@@ -82,14 +112,6 @@ interface Props {
   setAddInfoStep: (addInfoStep: AddInfoStep | null) => void;
 }
 
-/**
- * List of results to display next for the current map bounds
- */
-export interface NextResults {
-  markers: google.maps.Marker[];
-  results: MarkerInfo[];
-}
-
 type SearchBoxes = 'main' | 'add-information';
 
 interface SearchBox {
@@ -98,6 +120,11 @@ interface SearchBox {
 }
 
 class MapComponent extends React.Component<Props, {}> {
+  private readonly data: MarkerData = {
+    hardcoded: new Map(),
+    firebase: new Map(),
+  };
+
   private map: MapInfo | null = null;
 
   private addInfoMapClickedListener:
@@ -107,6 +134,15 @@ class MapComponent extends React.Component<Props, {}> {
   private readonly searchBoxes = new Map<SearchBoxes, SearchBox>();
 
   private infoWindow: google.maps.InfoWindow | null = null;
+
+  public constructor(props: Props) {
+    super(props);
+
+    // Initialize hardocded data
+    MARKERS.forEach((marker, index) =>
+      this.data.hardcoded.set(index.toString(), marker),
+    );
+  }
 
   public componentDidMount() {
     const { setUpdateResultsCallback } = this.props;
@@ -119,7 +155,7 @@ class MapComponent extends React.Component<Props, {}> {
     const { filter, results, nextResults, selectedResult } = this.props;
     // Update filter if changed
     if (this.map && !isEqual(filter, this.map.currentFilter)) {
-      updateMarkersVisibilityUsingFilter(this.map.markers, filter);
+      // updateMarkersVisibilityUsingFilter(this.map.markers, filter);
       this.map.markerClusterer.repaint();
       this.map.currentFilter = filter;
     }
@@ -160,48 +196,84 @@ class MapComponent extends React.Component<Props, {}> {
     return false;
   };
 
+  private getMarkerInfo = (
+    marker: google.maps.Marker,
+  ): MarkerIdAndInfo | null => {
+    const id = getMarkerId(marker);
+    const info = this.data[id.set].get(id.id);
+    return info ? { id, info } : null;
+  };
+
+  private initializeMarkers = <Set extends DataSet>(
+    activeMarkers: ActiveMarkers,
+    set: Set,
+  ) => {
+    const data = this.data[set];
+    for (const [id, info] of data) {
+      const marker = new window.google.maps.Marker({
+        position: {
+          lat: info.loc.latlng.latitude,
+          lng: info.loc.latlng.longitude,
+        },
+        title: info.contentTitle,
+      });
+      const idData: MarkerId = { set, id };
+      marker.set(MARKER_DATA_ID, idData);
+      activeMarkers[set].set(id, marker);
+
+      // Add marker listeners
+      marker.addListener('click', event => {
+        const { setSelectedResult } = this.props;
+        if (!this.mapClicked(event)) {
+          const i = this.getMarkerInfo(marker);
+          if (i) {
+            setSelectedResult(i);
+          }
+        }
+      });
+    }
+  };
+
   private updateGoogleMapRef = (ref: HTMLDivElement | null) => {
-    const { filter, setSelectedResult } = this.props;
+    const { filter } = this.props;
     if (!ref) {
       return;
     }
     const map = createGoogleMap(ref);
-    const markers = new Map<MarkerInfo, google.maps.Marker>();
-    for (const m of MARKERS) {
-      const marker = new window.google.maps.Marker({
-        position: {
-          lat: m.loc.latlng.latitude,
-          lng: m.loc.latlng.longitude,
-        },
-        title: m.contentTitle,
-      });
-      marker.set('info', m);
-      markers.set(m, marker);
+    const activeMarkers: ActiveMarkers = {
+      firebase: new Map(),
+      hardcoded: new Map(),
+    };
+
+    // Create initial markers
+    for (const set of ['hardcoded', 'firebase'] as const) {
+      this.initializeMarkers(activeMarkers, set);
     }
 
+    const allMarkers = [
+      ...activeMarkers.hardcoded.values(),
+      ...activeMarkers.firebase.values(),
+    ];
+
     // Add a marker clusterer to manage the markers.
-    const markerClusterer = new MarkerClusterer(
-      map,
-      Array.from(markers.values()),
-      {
-        imagePath:
-          'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m',
-        ignoreHidden: true,
-        zoomOnClick: false,
-        averageCenter: true,
-        gridSize: 30,
-      },
-    );
+    const markerClusterer = new MarkerClusterer(map, allMarkers, {
+      imagePath:
+        'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m',
+      ignoreHidden: true,
+      zoomOnClick: false,
+      averageCenter: true,
+      gridSize: 30,
+    });
 
     const m: MapInfo = {
       map,
-      markers,
+      activeMarkers,
       currentFilter: filter,
       markerClusterer,
     };
     this.map = m;
 
-    updateMarkersVisibilityUsingFilter(markers, filter);
+    // updateMarkersVisibilityUsingFilter(markers, filter);
 
     map.addListener('bounds_changed', () => {
       const bounds = map.getBounds();
@@ -215,34 +287,23 @@ class MapComponent extends React.Component<Props, {}> {
       }
     });
 
-    // We iterate over all locations to create markers
-    // This pretty much orchestrates everything since the map is the main interaction window
-    markers.forEach(marker => {
-      const info = getInfo(marker);
-
-      marker.addListener('click', event => {
-        if (!this.mapClicked(event)) {
-          setSelectedResult(info);
-        }
-      });
-
-      return marker;
-    });
-
     const drawMarkerServiceArea = (marker: google.maps.Marker) => {
       if (m.clustering?.state !== 'idle') {
         return;
       }
 
-      const info = getInfo(marker);
-      const { color } = MARKER_TYPES[info.type.type];
+      const info = this.getMarkerInfo(marker);
+      if (!info) {
+        return;
+      }
+      const { color } = MARKER_TYPES[info.info.type.type];
 
       const mapBoundingBox = map.getBounds();
       if (mapBoundingBox) {
         const topRight = mapBoundingBox.getNorthEast();
         const bottomLeft = mapBoundingBox.getSouthWest();
         const markerPosition = marker.getPosition();
-        const radius = info.loc.serviceRadius;
+        const radius = info.info.loc.serviceRadius;
 
         // Now compare the distance from the marker to corners of the box;
         if (markerPosition) {
@@ -293,10 +354,12 @@ class MapComponent extends React.Component<Props, {}> {
       // Immidiately change the result list to the cluster instead
       // Don't update nextResults as we want that to still be for the current
       // viewport
-      this.updateResultsTo({
-        markers: cluster.getMarkers(),
-        results: cluster.getMarkers().map(marker => getInfo(marker)),
-      });
+      this.updateResultsTo(
+        cluster
+          .getMarkers()
+          .map(marker => this.getMarkerInfo(marker))
+          .filter(isDefined),
+      );
     });
 
     // The clusters have been computed so we can
@@ -320,19 +383,21 @@ class MapComponent extends React.Component<Props, {}> {
           // Figure out which marker in each cluster will generate a circle.
           for (const marker of clusterMarkers) {
             // Update maxMarker to higher value if found.
-            const info = getInfo(marker);
-            if (
-              !maxMarker ||
-              maxMarker.serviceRadius < info.loc.serviceRadius
-            ) {
-              maxMarker = {
-                marker,
-                serviceRadius: info.loc.serviceRadius,
-              };
-            }
-            visibleMarkers.push(marker);
-            if (clusterMarkers.length > 1) {
-              m.clustering.clusterMarkers.set(marker, center);
+            const info = this.getMarkerInfo(marker);
+            if (info) {
+              if (
+                !maxMarker ||
+                maxMarker.serviceRadius < info.info.loc.serviceRadius
+              ) {
+                maxMarker = {
+                  marker,
+                  serviceRadius: info.info.loc.serviceRadius,
+                };
+              }
+              visibleMarkers.push(marker);
+              if (clusterMarkers.length > 1) {
+                m.clustering.clusterMarkers.set(marker, center);
+              }
             }
           }
 
@@ -347,10 +412,9 @@ class MapComponent extends React.Component<Props, {}> {
         visibleMarkers.sort(generateSortBasedOnMapCenter(mapCenter));
 
         // Store the next results in the state
-        const nextResults = {
-          markers: visibleMarkers,
-          results: visibleMarkers.map(marker => getInfo(marker)),
-        };
+        const nextResults = visibleMarkers
+          .map(marker => this.getMarkerInfo(marker))
+          .filter(isDefined);
 
         const {
           setNextResults: updateNextResults,
@@ -373,24 +437,31 @@ class MapComponent extends React.Component<Props, {}> {
 
   private updateResults = () => {
     const { results, nextResults } = this.props;
-    if (this.map && nextResults && results !== nextResults.results) {
+    if (this.map && nextResults && results !== nextResults) {
       this.updateResultsTo(nextResults);
     }
   };
 
-  private updateResultsTo = (results: NextResults) => {
+  private updateResultsTo = (results: MarkerIdAndInfo[]) => {
     const { setResults } = this.props;
     if (this.map) {
       // Clear all existing marker labels
-      for (const marker of this.map.markers.values()) {
+      for (const marker of [
+        ...this.map.activeMarkers.hardcoded.values(),
+        ...this.map.activeMarkers.firebase.values(),
+      ]) {
         marker.setLabel('');
       }
+      const { activeMarkers } = this.map;
+      const visibleMarkers = results
+        .map(({ id }) => activeMarkers[id.set].get(id.id))
+        .filter(isDefined);
       // Relabel marker labels based on theri index
-      results.markers.forEach((marker, index) => {
+      visibleMarkers.forEach((marker, index) => {
         marker.setLabel((index + 1).toString());
       });
       // Update the new results state
-      setResults(results.results);
+      setResults(results);
     }
   };
 
@@ -403,12 +474,14 @@ class MapComponent extends React.Component<Props, {}> {
     if (!this.map) {
       return;
     }
-    const marker = selectedResult && this.map.markers.get(selectedResult);
+    const marker =
+      selectedResult &&
+      this.map.activeMarkers[selectedResult.id.set].get(selectedResult.id.id);
     if (selectedResult && marker) {
       const clusterCenter =
         this.map.clustering?.state === 'idle' &&
         this.map.clustering.clusterMarkers.get(marker);
-      const contentString = infoWindowContent(selectedResult);
+      const contentString = infoWindowContent(selectedResult.info);
       if (!this.infoWindow) {
         this.infoWindow = new window.google.maps.InfoWindow({
           content: contentString,
@@ -528,7 +601,7 @@ class MapComponent extends React.Component<Props, {}> {
       addInfoStep,
       setAddInfoStep,
     } = this.props;
-    const hasNewResults = nextResults && nextResults.results !== results;
+    const hasNewResults = nextResults && nextResults !== results;
     const ExpandIcon = resultsMode === 'open' ? MdExpandMore : MdExpandLess;
     return (
       <AppContext.Consumer>

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -232,6 +232,7 @@ class MapComponent extends React.Component<Props, {}> {
 
   private informationUpdated: firebase.InformationListener = update => {
     // Update existing markers, add new markers and delete removed markers
+    this.data.firebase = update.markers;
     if (this.map) {
       // Update existing markers and add new markers
       const newMarkers: google.maps.Marker[] = [];
@@ -262,8 +263,6 @@ class MapComponent extends React.Component<Props, {}> {
       this.map.markerClusterer.removeMarkers(removedMarkers, true);
       this.map.markerClusterer.repaint();
     }
-    this.data.firebase = update.markers;
-    // TODO: redraw cluster circles
   };
 
   private updateGoogleMapRef = (ref: HTMLDivElement | null) => {

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -76,19 +76,6 @@ export interface MarkerIdAndInfo {
 const getMarkerId = (marker: google.maps.Marker): MarkerId =>
   marker.get(MARKER_DATA_ID);
 
-// const updateMarkersVisibilityUsingFilter = (
-//   markerData: MarkerData,
-//   markers: ActiveMarkers,
-//   filter: Filter,
-// ) => {
-//   for (const marker of [...markers.hardcoded.values(), ...markers.firebase.values()]) {
-//     const id = getId(marker);
-//     const info = getInfo(marker);
-//     const visible = !filter.type || info.type.type === filter.type;
-//     marker.setVisible(visible);
-//   }
-// };
-
 interface Props {
   className?: string;
   filter: Filter;
@@ -155,7 +142,7 @@ class MapComponent extends React.Component<Props, {}> {
     const { filter, results, nextResults, selectedResult } = this.props;
     // Update filter if changed
     if (this.map && !isEqual(filter, this.map.currentFilter)) {
-      // updateMarkersVisibilityUsingFilter(this.map.markers, filter);
+      this.updateMarkersVisibilityUsingFilter(filter);
       this.map.markerClusterer.repaint();
       this.map.currentFilter = filter;
     }
@@ -174,6 +161,19 @@ class MapComponent extends React.Component<Props, {}> {
     setUpdateResultsCallback(null);
     firebase.removeInformationListener(this.informationUpdated);
   }
+
+  private updateMarkersVisibilityUsingFilter = (filter: Filter) => {
+    if (this.map) {
+      for (const marker of [
+        ...this.map.activeMarkers.hardcoded.values(),
+        ...this.map.activeMarkers.firebase.values(),
+      ]) {
+        const info = this.getMarkerInfo(marker);
+        const visible = !filter.type || info?.info.type.type === filter.type;
+        marker.setVisible(visible);
+      }
+    }
+  };
 
   private setAddInfoMapClickedListener = (
     listener: ((evt: google.maps.MouseEvent) => void) | null,
@@ -308,7 +308,7 @@ class MapComponent extends React.Component<Props, {}> {
     };
     this.map = m;
 
-    // updateMarkersVisibilityUsingFilter(markers, filter);
+    this.updateMarkersVisibilityUsingFilter(filter);
 
     map.addListener('bounds_changed', () => {
       const bounds = map.getBounds();

--- a/map/src/components/results.tsx
+++ b/map/src/components/results.tsx
@@ -5,9 +5,10 @@ import {
   MdLanguage,
   MdPhone,
 } from 'react-icons/md';
-import { ContactDetails, MarkerInfo } from 'src/data/markers';
+import { MarkerIdAndInfo } from 'src/components/map';
+import { ContactDetails } from 'src/data/markers';
 import { format, Language, t } from 'src/i18n';
-import { button, buttonPrimary } from 'src/styling/mixins';
+import { buttonPrimary } from 'src/styling/mixins';
 
 import styled, { CLS_SCREEN_LG_HIDE, CLS_SCREEN_LG_ONLY } from '../styling';
 import { AppContext } from './context';
@@ -15,11 +16,11 @@ import MarkerType from './marker-type';
 
 interface Props {
   className?: string;
-  results: MarkerInfo[] | null;
-  nextResults: MarkerInfo[] | null;
+  results: MarkerIdAndInfo[] | null;
+  nextResults?: MarkerIdAndInfo[];
   updateResults: () => void;
-  selectedResult: MarkerInfo | null;
-  setSelectedResult: (selectedResult: MarkerInfo | null) => void;
+  selectedResult: MarkerIdAndInfo | null;
+  setSelectedResult: (selectedResult: MarkerIdAndInfo | null) => void;
 }
 
 const contactInfo = (lang: Language, label: string, info?: ContactDetails) => {
@@ -142,39 +143,43 @@ const Results = (props: Props) => {
               >
                 <div className="number">{index + 1}</div>
                 <div className="info">
-                  {result.loc.description && (
-                    <div className="location">{result.loc.description}</div>
+                  {result.info.loc.description && (
+                    <div className="location">
+                      {result.info.loc.description}
+                    </div>
                   )}
-                  <div className="name">{result.contentTitle}</div>
-                  <MarkerType type={result.type} />
+                  <div className="name">{result.info.contentTitle}</div>
+                  <MarkerType type={result.info.type} />
                 </div>
               </div>
             ))}
           </div>
           {selectedResult && (
             <div className="details">
-              <div className="name">{selectedResult.contentTitle}</div>
-              {selectedResult.loc.description && (
-                <div className="location">{selectedResult.loc.description}</div>
+              <div className="name">{selectedResult.info.contentTitle}</div>
+              {selectedResult.info.loc.description && (
+                <div className="location">
+                  {selectedResult.info.loc.description}
+                </div>
               )}
-              <MarkerType type={selectedResult.type} />
-              {selectedResult.contentBody && (
-                <div className="content">{selectedResult.contentBody}</div>
+              <MarkerType type={selectedResult.info.type} />
+              {selectedResult.info.contentBody && (
+                <div className="content">{selectedResult.info.contentBody}</div>
               )}
               {contactInfo(
                 lang,
                 t(lang, s => s.results.contact.general),
-                selectedResult.contact.general,
+                selectedResult.info.contact.general,
               )}
               {contactInfo(
                 lang,
                 t(lang, s => s.results.contact.getHelp),
-                selectedResult.contact.getHelp,
+                selectedResult.info.contact.getHelp,
               )}
               {contactInfo(
                 lang,
                 t(lang, s => s.results.contact.volunteer),
-                selectedResult.contact.volunteers,
+                selectedResult.info.contact.volunteers,
               )}
             </div>
           )}

--- a/map/src/data/firebase.ts
+++ b/map/src/data/firebase.ts
@@ -15,9 +15,97 @@ const config = {
   measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
 };
 
+const isValidMarkerInfo = (
+  data: firebase.firestore.DocumentData,
+): data is MarkerInfo =>
+  // TODO
+  !!data;
+
+const MARKER_COLLECTION_ID = 'markers';
+
 firebase.initializeApp(config);
 const db = firebase.firestore();
+const markers = db.collection(MARKER_COLLECTION_ID);
 
 export const submitInformation = async (info: MarkerInfo) => {
-  await db.collection('markers').add(info);
+  await markers.add(info);
+};
+
+export interface InformationUpdate {
+  loading: boolean;
+  markers: Map<string, MarkerInfo>;
+}
+
+export type InformationListener = (event: InformationUpdate) => void;
+
+const listeners = new Set<InformationListener>();
+const state: {
+  initialLoadDone: boolean;
+  loadingOperations: Set<Promise<unknown>>;
+  markers: Map<string, MarkerInfo>;
+  errors: Set<Error>;
+} = {
+  initialLoadDone: false,
+  loadingOperations: new Set(),
+  markers: new Map(),
+  errors: new Set(),
+};
+
+const getInfoForListeners = (): InformationUpdate => ({
+  loading: state.loadingOperations.size > 0,
+  markers: state.markers,
+});
+
+const updateListeners = () => {
+  const data = getInfoForListeners();
+  listeners.forEach(l => l(data));
+};
+
+/**
+ * Store the promise in state, update listeners,
+ * and setup appropriate handlers
+ */
+const processPromise = (promise: Promise<unknown>) => {
+  state.loadingOperations.add(promise);
+  updateListeners();
+  promise.then(
+    () => {
+      state.loadingOperations.delete(promise);
+      updateListeners();
+    },
+    err => {
+      state.loadingOperations.delete(promise);
+      state.errors.add(err);
+      updateListeners();
+    },
+  );
+};
+
+export const addInformationListener = (l: InformationListener) => {
+  listeners.add(l);
+  l(getInfoForListeners());
+};
+
+export const removeInformationListener = (l: InformationListener) => {
+  listeners.delete(l);
+};
+
+export const loadInitialData = () => {
+  if (state.initialLoadDone) {
+    return;
+  }
+  state.initialLoadDone = true;
+  const promise = markers
+    .where(new firebase.firestore.FieldPath('visible'), '==', false)
+    .get()
+    .then(snapshot => {
+      snapshot.forEach(doc => {
+        const data = doc.data();
+        if (isValidMarkerInfo(data)) {
+          state.markers.set(doc.id, data);
+        }
+      });
+    });
+  processPromise(promise);
+  return promise;
 };

--- a/map/src/data/markers.ts
+++ b/map/src/data/markers.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase';
+import firebase from 'firebase/app';
 
 /* eslint max-len: 0 */
 import { MarkerType } from './index';

--- a/map/src/i18n/index.tsx
+++ b/map/src/i18n/index.tsx
@@ -114,7 +114,7 @@ export const { addListener } = manager;
 export const { removeListener } = manager;
 
 interface Placeholders {
-  [key: string]: JSX.Element;
+  [key: string]: (key: number) => JSX.Element;
 }
 
 interface FormatValues {
@@ -143,18 +143,20 @@ export function t(
   while (next) {
     const e = placeholderExtraction.exec(next);
     if (!e) {
-      components.push(<span>{next}</span>);
+      components.push(<span key={components.length}>{next}</span>);
       next = null;
     } else {
       const [, prev, placeholderTag, remaining] = e;
-      components.push(<span>{prev}</span>);
+      components.push(<span key={components.length}>{prev}</span>);
       const component = placeholders[placeholderTag];
       if (!component) {
         // eslint-disable-next-line no-console
         console.log('Unknown i18n placeholder:', placeholderTag);
       }
       components.push(
-        component || <span style={{ color: '#f00' }}>ERROR</span>,
+        component(components.length) || (
+          <span style={{ color: '#f00' }}>ERROR</span>
+        ),
       );
       next = remaining;
     }

--- a/map/src/i18n/langs/en.json
+++ b/map/src/i18n/langs/en.json
@@ -145,6 +145,8 @@
     "netlifyNote": "This map {link}",
     "netlifyLinkText": "is hosted by Netlify",
     "githubRepo": "GitHub Repo",
-    "codeOfConduct": "Code of Conduct"
+    "codeOfConduct": "Code of Conduct",
+    "showHidden": "Show Hidden Information",
+    "hideHidden": "Hide Hidden Information"
   }
 }

--- a/map/src/util/index.ts
+++ b/map/src/util/index.ts
@@ -1,3 +1,7 @@
 export type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
+
+export const isDefined = <T extends unknown>(
+  val: T | undefined | null,
+): val is T => val !== undefined && val !== null;


### PR DESCRIPTION
## Description

This PR modifies the map to load the latest set of markers from the firebase database when the page loads. It also allows users to toggle whether or not "hidden" information is shown using a discreet button in the footer. The rationale behind this is that, for those submitting new information, we want them to be able to see whether anything else has been submitted / proposed in that same area before doing so themselves.

Right now the old data is still hard-coded, but we should migrate it over some time soon.

TODO (in later PRs probably):

* Make it obvious when a marker is "hidden" (e.g. less opacity? Note on the info page?)
* Automatically refresh results when users change filter / toggle visibility and their map position is unchanged.
* store a users preference to show hidden markers in localstorage.
* Add a message to the addInfo screen advising users to enable hidden markers and check for duplicates before submitting.

## Release Checklist

- [ ] This code has unit tests
- [x] I have a plan to verify that these changes are working as expected after deploy
- [x] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->
