### PR TITLE
feat(map): enable anonymous (cookie-less) analytics using matomo

### DIFF
--- a/map/public/index.html
+++ b/map/public/index.html
@@ -56,6 +56,22 @@
       }
     </style>
 
+    <!-- Matomo -->
+    <script type="text/javascript">
+      var _paq = window._paq || [];
+      _paq.push(['disableCookies']);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function () {
+        var u = "//matomo.reach4help.org/";
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+        g.type = 'text/javascript'; g.async = true; g.defer = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
+
   </head>
   <body>
     <script>

--- a/map/src/components/about.tsx
+++ b/map/src/components/about.tsx
@@ -6,6 +6,7 @@ import styled, {
   NON_LARGE_DEVICES,
   Z_INDICES,
 } from 'src/styling';
+import { trackEvent } from 'src/util/tracking';
 
 import Marker from './assets/marker';
 import { AppContext } from './context';
@@ -57,7 +58,10 @@ const About = ({ className, page, setPage }: Props) => (
           <button
             type="button"
             className="view-map"
-            onClick={() => setPage({ page: 'map' })}
+            onClick={() => {
+              trackEvent('cta', 'home-map');
+              setPage({ page: 'map' });
+            }}
           >
             {t(lang, s => s.menu.map)}
           </button>

--- a/map/src/components/add-information.tsx
+++ b/map/src/components/add-information.tsx
@@ -21,6 +21,7 @@ import {
 import { format, Language, t } from 'src/i18n';
 import { AddInfoStep, Page } from 'src/state';
 import { isDefined, RecursivePartial } from 'src/util';
+import { trackEvent } from 'src/util/tracking';
 
 import {
   isMarkerType,
@@ -402,9 +403,11 @@ class AddInstructions extends React.Component<Props, State> {
     }
     if (validation.errors.length > 0) {
       this.setState({ validation });
+      trackEvent('data-entry', 'complete-info-error');
     } else {
       this.setAddInfoStep('place-marker');
       this.setState({ validation: undefined });
+      trackEvent('data-entry', 'complete-info');
     }
   };
 
@@ -425,9 +428,11 @@ class AddInstructions extends React.Component<Props, State> {
     }
     if (validation.errors.length > 0) {
       this.setState({ validation });
+      trackEvent('data-entry', 'complete-placement-error');
     } else {
       this.setAddInfoStep('contact-details');
       this.setState({ validation: undefined });
+      trackEvent('data-entry', 'complete-placement');
     }
   };
 
@@ -543,6 +548,7 @@ class AddInstructions extends React.Component<Props, State> {
       }
       if (validation.errors.length > 0) {
         this.setState({ validation });
+        trackEvent('data-entry', 'complete-contact-info-error');
       } else {
         this.setAddInfoStep('submitted');
         this.setState({ validation: undefined, submissionResult: undefined });
@@ -569,6 +575,7 @@ class AddInstructions extends React.Component<Props, State> {
               }),
           );
         }
+        trackEvent('data-entry', 'complete-contact-info');
       }
     });
   };
@@ -577,6 +584,7 @@ class AddInstructions extends React.Component<Props, State> {
     this.setState(INITIAL_STATE);
     this.setAddInfoStep('information');
     this.removeMarkers();
+    trackEvent('data-entry', 'add-more');
   };
 
   private validatedInput = (

--- a/map/src/components/header.tsx
+++ b/map/src/components/header.tsx
@@ -12,6 +12,7 @@ import styled, {
   SMALL_DEVICES,
   Z_INDICES,
 } from 'src/styling';
+import { trackEvent } from 'src/util/tracking';
 
 const MENU = ['about', 'map'] as const;
 
@@ -53,6 +54,10 @@ class Header extends React.Component<Props, State> {
                     page: 'add-information',
                     step: 'information',
                   },
+            );
+            trackEvent(
+              'nav',
+              page.page === 'add-information' ? 'back-to-map' : 'add-info',
             );
             this.setState({ open: false });
           }}
@@ -96,6 +101,7 @@ class Header extends React.Component<Props, State> {
                     className={page.page === p ? 'selected' : ''}
                     type="button"
                     onClick={() => {
+                      trackEvent('nav', 'main', p);
                       setPage({ page: p });
                       this.setState({ open: false });
                     }}

--- a/map/src/components/languages.tsx
+++ b/map/src/components/languages.tsx
@@ -8,6 +8,7 @@ import {
   LANGUAGES,
   setLanguage,
 } from 'src/i18n';
+import { trackEvent } from 'src/util/tracking';
 
 import styled from '../styling';
 import { AppContext } from './context';
@@ -38,6 +39,7 @@ class Languages extends React.Component<Props, {}> {
   private changeLanguage = (option: ValueType<Option>): void => {
     if (isOption(option)) {
       setLanguage(option.value);
+      trackEvent('config', 'change-language', option.value);
     }
   };
 

--- a/map/src/util/tracking.ts
+++ b/map/src/util/tracking.ts
@@ -1,0 +1,46 @@
+declare global {
+  interface Window {
+    _paq: Array<
+      | ['trackEvent', string, string]
+      | ['trackEvent', string, string, string]
+      | ['trackEvent', string, string, string, number]
+    >;
+  }
+}
+
+export function trackEvent(
+  category: 'data-entry',
+  action:
+    | 'complete-info'
+    | 'complete-info-error'
+    | 'complete-placement'
+    | 'complete-placement-error'
+    | 'complete-contact-info'
+    | 'complete-contact-info-error'
+    | 'add-more',
+): void;
+export function trackEvent(
+  category: 'config',
+  action: 'change-language',
+  language: string,
+): void;
+export function trackEvent(
+  category: 'nav',
+  action: 'add-info' | 'back-to-map',
+): void;
+export function trackEvent(category: 'nav', action: 'main', page: string): void;
+export function trackEvent(category: 'cta', action: 'home-map'): void;
+export function trackEvent(
+  category: string,
+  action: string,
+  eventName?: string,
+  value?: number,
+) {
+  if (value && eventName) {
+    window._paq.push(['trackEvent', category, action, eventName, value]);
+  } else if (eventName) {
+    window._paq.push(['trackEvent', category, action, eventName]);
+  } else {
+    window._paq.push(['trackEvent', category, action]);
+  }
+}


### PR DESCRIPTION
I've now deployed an instance of matomo to matomo.reach4help.org
with a letsencrypt TLS certificate (using bitnami). I've disabled
cookies completely in the tracking code, and it seems to work well
this should give us more than enough statistics for our site, and
we don't need to ask consent to drop cookies either!

Closes #290 
Closes #291 