### PR TITLE
Backend: introduce a REST API that allows people to consume our map data

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -2,13 +2,19 @@
   "projects": {
     "default": "reach4help-dev",
     "staging": "reach4help-staging",
-    "production": "reach4help-34372"
+    "production": "reach4help"
   },
   "targets": {
     "reach4help-dev": {
       "hosting": {
         "web-client": [
           "reach4help-dev-web-client"
+        ],
+        "map": [
+          "reach4help-dev-map-web"
+        ],
+        "api": [
+          "reach4help-dev-api"
         ]
       }
     },
@@ -16,13 +22,25 @@
       "hosting": {
         "web-client": [
           "reach4help-staging-web-client"
+        ],
+        "map": [
+          "reach4help-staging-map"
+        ],
+        "api": [
+          "reach4help-staging-api"
         ]
       }
     },
-    "reach4help-34372": {
+    "reach4help": {
       "hosting": {
         "web-client": [
           "reach4help-web-client"
+        ],
+        "map": [
+          "reach4help-map-site"
+        ],
+        "api": [
+          "reach4help-api"
         ]
       }
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: 10.x
 
       - name: Install Deps
-        run: cd functions && yarn install
+        run: yarn install && cd functions && yarn install
 
       - name: Lint
         run: cd functions && yarn run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,5 @@ jobs:
       - name: Install Deps
         run: cd functions && yarn install
 
-      - name: Lint
+      - name: Run Unit Tests
         run: cd functions && yarn run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,20 @@ jobs:
 
       - name: Lint
         run: cd functions && yarn run lint
+  test-functions:
+    name: Run functions unit-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+
+      - name: Install Deps
+        run: cd functions && yarn install
+
+      - name: Lint
+        run: cd functions && yarn run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,20 @@ jobs:
 
       - name: Lint
         run: yarn run lint
+  lint-functions:
+    name: Run linters on functions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+
+      - name: Install Deps
+        run: cd functions && yarn install
+
+      - name: Lint
+        run: cd functions && yarn run lint

--- a/api/public/index.html
+++ b/api/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>API - Reach4Help</title>
+</head>
+
+<body>
+  For more info, see <a href="https://reach4help.org">reach4help.org</a>.
+</body>
+
+</html>

--- a/firebase.json
+++ b/firebase.json
@@ -25,6 +25,36 @@
           "destination": "/index.html"
         }
       ]
+    },
+    {
+      "target": "map",
+      "public": "map/build",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    },
+    {
+      "public": "api/public",
+      "target": "api",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "/edge/map/data",
+          "function": "https-api-map-data"
+        }
+      ]
     }
   ],
   "storage": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
     "test": "yarn run test:firestore && yarn run test:triggers",
     "lint": "eslint . --ext .ts && prettier --check \"./**/*.ts\"",
     "lint:fix": "eslint . --fix --ext .ts && prettier --write \"./**/*.ts\"",
-    "build": "tsc --build src/tsconfig.json",
+    "build": "rm -rf lib && tsc --build src/tsconfig.json",
     "serve": "yarn run build && firebase emulators:start",
     "shell": "yarn run build && firebase functions:shell",
     "start": "yarn run shell",

--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -2,8 +2,8 @@ import * as admin from 'firebase-admin';
 
 import { config } from './config/config';
 
-let internalApp: any;
-let internalDB: any;
+let internalApp: admin.app.App;
+let internalDB: FirebaseFirestore.Firestore;
 let internalAuth: admin.auth.Auth | null;
 
 if (config.get('env') !== 'test') {

--- a/functions/src/app.ts
+++ b/functions/src/app.ts
@@ -1,5 +1,4 @@
 import * as admin from 'firebase-admin';
-import * as firebaseTest from '@firebase/testing';
 
 import { config } from './config/config';
 
@@ -12,6 +11,10 @@ if (config.get('env') !== 'test') {
   internalDB = admin.firestore();
   internalAuth = admin.auth();
 } else {
+  // Only import when we're in a test environment
+  // (as dependency is only included in devDependencies)
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  const firebaseTest = require('@firebase/testing');
   internalApp = firebaseTest.initializeAdminApp({ projectId: 'reach-4-help-test' });
   internalDB = internalApp.firestore();
   internalAuth = null;

--- a/functions/src/dispatch/fcm.ts
+++ b/functions/src/dispatch/fcm.ts
@@ -3,4 +3,4 @@ import { app } from '../app';
 
 const messaging = app.messaging();
 
-export const sendToTopic = async (config: Admin.messaging.Message) => messaging.send(config);
+export const sendToTopic = (config: Admin.messaging.Message) => messaging.send(config);

--- a/functions/src/https/api/index.ts
+++ b/functions/src/https/api/index.ts
@@ -1,0 +1,3 @@
+import * as map from './map';
+
+export { map };

--- a/functions/src/https/api/map/index.ts
+++ b/functions/src/https/api/map/index.ts
@@ -48,5 +48,6 @@ export const data = functions.https.onRequest(async (_req, res) => {
     }
   });
   res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=600');
   res.status(200).send(JSON.stringify(result));
 });

--- a/functions/src/https/api/map/index.ts
+++ b/functions/src/https/api/map/index.ts
@@ -1,0 +1,47 @@
+import * as functions from 'firebase-functions';
+
+import { db } from '../../../app';
+
+import { IMarker, MARKER_COLLECTION_ID } from '../../../models/markers';
+
+/* eslint-disable max-len */
+const LICENSES = {
+  reach4help:
+    'This data by Reach4Help (https://reach4help.org/) is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License (http://creativecommons.org/licenses/by-nc-sa/4.0/)',
+  // TODO: uncomment when license is confirmed with mutualaid.wiki
+  // 'mutualaid.wiki': `This data by Mutual Aid Wiki (https://mutualaid.wiki/) is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License (http://creativecommons.org/licenses/by-nc-sa/4.0/)`
+};
+/* eslint-enable max-len */
+
+type LicenseKey = keyof typeof LICENSES;
+
+interface Marker extends IMarker {
+  id: string;
+  license: LicenseKey;
+}
+
+interface Result {
+  licenses: typeof LICENSES;
+  data: Marker[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+export const data = functions.https.onRequest(async (_req, res) => {
+  const result: Result = {
+    licenses: LICENSES,
+    data: [],
+  };
+  const markers = await db.collection(MARKER_COLLECTION_ID).get();
+  markers.forEach(doc => {
+    const docData = doc.data() as IMarker;
+    // TODO: add other sources (with appropriate licenses)
+    if (!docData.source) {
+      result.data.push({
+        ...docData,
+        id: doc.id,
+        license: 'reach4help',
+      });
+    }
+  });
+  res.status(200).send(JSON.stringify(result));
+});

--- a/functions/src/https/api/map/index.ts
+++ b/functions/src/https/api/map/index.ts
@@ -1,4 +1,5 @@
 import * as functions from 'firebase-functions';
+import { FieldPath } from '@google-cloud/firestore';
 
 import { db } from '../../../app';
 
@@ -31,7 +32,10 @@ export const data = functions.https.onRequest(async (_req, res) => {
     licenses: LICENSES,
     data: [],
   };
-  const markers = await db.collection(MARKER_COLLECTION_ID).get();
+  const markers = await db
+    .collection(MARKER_COLLECTION_ID)
+    .where(new FieldPath('visible'), '==', true)
+    .get();
   markers.forEach(doc => {
     const docData = doc.data() as IMarker;
     // TODO: add other sources (with appropriate licenses)

--- a/functions/src/https/api/map/index.ts
+++ b/functions/src/https/api/map/index.ts
@@ -43,5 +43,6 @@ export const data = functions.https.onRequest(async (_req, res) => {
       });
     }
   });
+  res.setHeader('Content-Type', 'application/json');
   res.status(200).send(JSON.stringify(result));
 });

--- a/functions/src/https/index.ts
+++ b/functions/src/https/index.ts
@@ -1,0 +1,3 @@
+import * as api from './api';
+
+export { api };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,5 @@
 // Init admin app for everyone else
-export * from './app';
+import './app';
 
 // Load everyone else
 export * from './users';

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,7 +1,11 @@
 // Init admin app for everyone else
 import './app';
 
+import * as https from './https';
+
 // Load everyone else
 export * from './users';
 export * from './requests';
 export * from './offers';
+
+export { https };

--- a/functions/src/models/markers/index.ts
+++ b/functions/src/models/markers/index.ts
@@ -7,6 +7,8 @@ import { MarkerType } from 'map/src/data';
 import DocumentData = firestore.DocumentData;
 import QueryDocumentSnapshot = firestore.QueryDocumentSnapshot;
 
+export const MARKER_COLLECTION_ID = 'markers';
+
 /**
  * Contact details capture various methods to contact an organization.
  */

--- a/functions/src/questionnaires/functions.ts
+++ b/functions/src/questionnaires/functions.ts
@@ -11,50 +11,47 @@ export const validateQuestionnaire = (value: IQuestionnaire): Promise<void> => {
   });
 };
 
-export const updateUserQuestionnaireRef = (snapshot: DocumentSnapshot, userId: string | undefined, claims: { pin?: boolean; cav?: boolean } | undefined): Promise<void> => {
-    const questionnaire = Questionnaire.factory(snapshot.data() as IQuestionnaire);
+export const updateUserQuestionnaireRef = (
+  snapshot: DocumentSnapshot,
+  userId: string | undefined,
+  claims: { pin?: boolean; cav?: boolean } | undefined,
+): Promise<void> => {
+  const questionnaire = Questionnaire.factory(snapshot.data() as IQuestionnaire);
 
-    // Only my questionnaires count and only if I am logged in for my own requests.
-    if (!userId || questionnaire.parentRef.id !== userId) {
-      return Promise.resolve();
-    }
-
-    const userRef = db.collection('users').doc(userId);
-    const operations: Promise<void>[] = [];
-
-    switch (questionnaire.type) {
-      case QuestionnaireType.pin:
-        operations.push(userRef
-          .update({ pinQuestionnaireRef: snapshot.ref })
-          .then());
-        if (!claims?.pin) {
-          // If I wasn't a PIN before... I am now
-          operations.push(setIsUserPin(userId, true));
-        }
-        break;
-      case QuestionnaireType.cav:
-        operations.push(userRef
-          .update({ cavQuestionnaireRef: snapshot.ref })
-          .then());
-        if (!claims?.cav) {
-          // If I wasn't a CAV before... I am now
-          operations.push(setIsUserCav(userId, true));
-        }
-        break;
-      default:
-        break;
-    }
-
-    return Promise.all(operations).then();
+  // Only my questionnaires count and only if I am logged in for my own requests.
+  if (!userId || questionnaire.parentRef.id !== userId) {
+    return Promise.resolve();
   }
-;
+
+  const userRef = db.collection('users').doc(userId);
+  const operations: Promise<void>[] = [];
+
+  switch (questionnaire.type) {
+    case QuestionnaireType.pin:
+      operations.push(userRef.update({ pinQuestionnaireRef: snapshot.ref }).then());
+      if (!claims?.pin) {
+        // If I wasn't a PIN before... I am now
+        operations.push(setIsUserPin(userId, true));
+      }
+      break;
+    case QuestionnaireType.cav:
+      operations.push(userRef.update({ cavQuestionnaireRef: snapshot.ref }).then());
+      if (!claims?.cav) {
+        // If I wasn't a CAV before... I am now
+        operations.push(setIsUserCav(userId, true));
+      }
+      break;
+    default:
+      break;
+  }
+
+  return Promise.all(operations).then();
+};
 
 export const onCreate = (snapshot: DocumentSnapshot, context: EventContext) => {
   return validateQuestionnaire(snapshot.data() as IQuestionnaire)
     .then(() => {
-      return Promise.all([
-        updateUserQuestionnaireRef(snapshot, context.auth?.uid, context.auth?.token),
-      ]);
+      return Promise.all([updateUserQuestionnaireRef(snapshot, context.auth?.uid, context.auth?.token)]);
     })
     .catch(errors => {
       console.error('Invalid Questionnaire Found: ', errors);

--- a/functions/src/questionnaires/index.ts
+++ b/functions/src/questionnaires/index.ts
@@ -1,6 +1,4 @@
 import * as functions from 'firebase-functions';
 import { onCreate } from './functions';
 
-export const triggerEventsWhenQuestionnaireIsCreated = functions.firestore
-  .document('questionnaires/{questionnaireId}')
-  .onCreate(onCreate);
+export const triggerEventsWhenQuestionnaireIsCreated = functions.firestore.document('questionnaires/{questionnaireId}').onCreate(onCreate);

--- a/functions/src/requests/functions.ts
+++ b/functions/src/requests/functions.ts
@@ -178,11 +178,7 @@ export const createRequest = (snapshot: DocumentSnapshot, context: EventContext)
 export const updateRequest = (change: Change<DocumentSnapshot>, context: EventContext) => {
   return validateRequest(change.after.data() as IRequest)
     .then(() => {
-      return Promise.all([
-        queueStatusUpdateTriggers(change),
-        queueRatingUpdatedTriggers(change),
-        indexRequest(change.after),
-      ]);
+      return Promise.all([queueStatusUpdateTriggers(change), queueRatingUpdatedTriggers(change), indexRequest(change.after)]);
     })
     .catch(() => {
       return db

--- a/functions/src/users/functions.ts
+++ b/functions/src/users/functions.ts
@@ -6,10 +6,9 @@ import { auth, db } from '../app';
 import DocumentSnapshot = admin.firestore.DocumentSnapshot;
 
 export const validateUser = (value: IUser): Promise<void> => {
-  return validateOrReject(User.factory(value))
-    .then(() => {
-      return Promise.resolve();
-    });
+  return validateOrReject(User.factory(value)).then(() => {
+    return Promise.resolve();
+  });
 };
 
 export const setIsUserPin = (userId: string, status: boolean): Promise<void> => {

--- a/functions/tests/triggers/user-triggers.test.ts
+++ b/functions/tests/triggers/user-triggers.test.ts
@@ -31,10 +31,13 @@ describe('user triggers', () => {
 
     const userRef = db.collection('users').doc('user1');
 
-    return userRef.set({ displayName: 'fsdfs' })
-      .then((): Promise<firebase.firestore.DocumentSnapshot> => {
-        return userRef.get();
-      })
+    return userRef
+      .set({ displayName: 'fsdfs' })
+      .then(
+        (): Promise<firebase.firestore.DocumentSnapshot> => {
+          return userRef.get();
+        },
+      )
       .then(snap => {
         return test.wrap(triggerEventsWhenUserIsCreated)(snap, {
           params: {
@@ -48,6 +51,5 @@ describe('user triggers', () => {
       .then(snapAfter => {
         expect(snapAfter.exists).toBeFalsy();
       });
-
   });
 });


### PR DESCRIPTION
## Description

This is based on #501 (so should get merged after)

Introduces a new firebase "host" at api.reach4help.org (see: https://api.reach4help.org/edge/map/data) for creating general API endpoints for interacting with other projects.

## Motivation

As part of our collaboration with mutualaid.wiki, they need an endpoint to be able to consume our data. Once the mutual aid data has been migrated over to mutualaid.wiki, and we instruct users to enter new group information there instead of using our form, then it's unlikely there will be a continued need for mutualaid.wiki to ue this API, but it will remain useful for others!

(Note: we still need to transfer the hard-coded data to our database, hence the low result count)

## Release Checklist

- [ ] This code has unit tests
- [x] I have a plan to verify that these changes are working as expected after deploy
- [x] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [x] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

cc @reach4help/security 

## Additional Notes

Closes #487

The majority of our data still needs to be migrated from JSON to our firestore database before it becomes available through this API.

cc @tapjay @Pingid 
