### PR TITLE
feat(request): allow cavs the ability to decline requests

### DIFF
--- a/functions/src/models/offers/index.ts
+++ b/functions/src/models/offers/index.ts
@@ -12,6 +12,7 @@ export enum OfferStatus {
   pending = 'pending',
   accepted = 'accepted',
   rejected = 'rejected',
+  cavRejected = 'cav_declined',
 }
 
 export interface IOffer extends DocumentData {

--- a/functions/src/models/offers/index.ts
+++ b/functions/src/models/offers/index.ts
@@ -12,7 +12,7 @@ export enum OfferStatus {
   pending = 'pending',
   accepted = 'accepted',
   rejected = 'rejected',
-  cavRejected = 'cav_declined',
+  cavDeclined = 'cav_declined',
 }
 
 export interface IOffer extends DocumentData {

--- a/web-client/src/models/offers/index.ts
+++ b/web-client/src/models/offers/index.ts
@@ -14,6 +14,7 @@ export enum OfferStatus {
   pending = 'pending',
   accepted = 'accepted',
   rejected = 'rejected',
+  cavRejected = 'cav_declined',
 }
 
 export interface IOffer extends firebase.firestore.DocumentData {

--- a/web-client/src/models/offers/index.ts
+++ b/web-client/src/models/offers/index.ts
@@ -14,7 +14,7 @@ export enum OfferStatus {
   pending = 'pending',
   accepted = 'accepted',
   rejected = 'rejected',
-  cavRejected = 'cav_declined',
+  cavDeclined = 'cav_declined',
 }
 
 export interface IOffer extends firebase.firestore.DocumentData {


### PR DESCRIPTION
## Description

Added an additional value to the OfferStatus enum so that CAVs can decline requests by submitting an offer with status: `cav_declined`

## Motivation

CAV's need a way to only see requests that they haven't interacted with.

This is done by querying requests within a window and then also querying offers with the same conditions. Client side, users will join those collections.

## Testing Guidelines

## Release Checklist

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
