### PR TITLE
fixes issues converting address for firestore and making applicationPreference optional

### DIFF
--- a/functions/src/models/users/index.ts
+++ b/functions/src/models/users/index.ts
@@ -29,7 +29,7 @@ export interface IUser extends DocumentData {
 export class User implements IUser {
   constructor(
     username: string,
-    applicationPreference?: ApplicationPreference | null,
+    applicationPreference: ApplicationPreference | null = null,
     pinQuestionnaireRef: DocumentReference<DocumentData> | null = null,
     cavQuestionnaireRef: DocumentReference<DocumentData> | null = null,
     casesCompleted = 0,
@@ -178,6 +178,7 @@ export class User implements IUser {
   }
 
   @IsEnum(ApplicationPreference)
+  @IsOptional()
   private _applicationPreference: ApplicationPreference | undefined | null;
 
   get applicationPreference(): ApplicationPreference | undefined | null {

--- a/functions/src/models/users/index.ts
+++ b/functions/src/models/users/index.ts
@@ -13,7 +13,7 @@ export enum ApplicationPreference {
 
 export interface IUser extends DocumentData {
   username: string;
-
+  applicationPreference?: ApplicationPreference | null;
   cavQuestionnaireRef?: DocumentReference<DocumentData> | null;
   pinQuestionnaireRef?: DocumentReference<DocumentData> | null;
   averageRating?: number | null;
@@ -23,13 +23,13 @@ export interface IUser extends DocumentData {
   cavRatingsReceived?: number;
   displayName?: string | null;
   displayPicture?: string | null;
-  applicationPreference?: ApplicationPreference;
   createdAt?: Timestamp;
 }
 
 export class User implements IUser {
   constructor(
     username: string,
+    applicationPreference?: ApplicationPreference | null,
     pinQuestionnaireRef: DocumentReference<DocumentData> | null = null,
     cavQuestionnaireRef: DocumentReference<DocumentData> | null = null,
     casesCompleted = 0,
@@ -39,7 +39,6 @@ export class User implements IUser {
     averageRating: number | null = null,
     displayName: string | null = null,
     displayPicture: string | null = null,
-    applicationPreference = ApplicationPreference.pin,
     createdAt = Timestamp.now(),
   ) {
     this._cavQuestionnaireRef = cavQuestionnaireRef;
@@ -179,13 +178,13 @@ export class User implements IUser {
   }
 
   @IsEnum(ApplicationPreference)
-  private _applicationPreference: ApplicationPreference;
+  private _applicationPreference: ApplicationPreference | undefined | null;
 
-  get applicationPreference(): ApplicationPreference {
+  get applicationPreference(): ApplicationPreference | undefined | null {
     return this._applicationPreference;
   }
 
-  set applicationPreference(value: ApplicationPreference) {
+  set applicationPreference(value: ApplicationPreference | undefined | null) {
     this._applicationPreference = value;
   }
 
@@ -206,6 +205,7 @@ export class User implements IUser {
   static factory = (data: IUser): User =>
     new User(
       data.username,
+      data.applicationPreference,
       data.pinQuestionnaireRef,
       data.cavQuestionnaireRef,
       data.casesCompleted,
@@ -215,7 +215,6 @@ export class User implements IUser {
       data.averageRating,
       data.displayName,
       data.displayPicture,
-      data.applicationPreference,
       data.createdAt,
     );
 

--- a/functions/src/models/users/privilegedInformation.ts
+++ b/functions/src/models/users/privilegedInformation.ts
@@ -134,14 +134,5 @@ export const PrivilegedUserInformationFirestoreConverter: FirestoreDataConverter
   fromFirestore: (data: QueryDocumentSnapshot<IPrivilegedUserInformation>): PrivilegedUserInformation => {
     return PrivilegedUserInformation.factory(data.data());
   },
-  toFirestore: (modelObject: PrivilegedUserInformation): DocumentData => {
-    return {
-      addressFromGoogle: modelObject.addressFromGoogle,
-      address: modelObject.address,
-      privacyAccepted: modelObject.privacyAccepted,
-      privacyVersion: modelObject.privacyVersion,
-      termsAccepted: modelObject.termsAccepted,
-      termsVersion: modelObject.termsVersion,
-    };
-  },
+  toFirestore: (modelObject: PrivilegedUserInformation): DocumentData => modelObject.toObject(),
 };

--- a/web-client/src/models/users/index.ts
+++ b/web-client/src/models/users/index.ts
@@ -20,7 +20,7 @@ export enum ApplicationPreference {
 
 export interface IUser extends firebase.firestore.DocumentData {
   username: string;
-
+  applicationPreference?: ApplicationPreference | null;
   cavQuestionnaireRef?: firebase.firestore.DocumentReference<
     firebase.firestore.DocumentData
   > | null;
@@ -34,13 +34,13 @@ export interface IUser extends firebase.firestore.DocumentData {
   cavRatingsReceived?: number;
   displayName?: string | null;
   displayPicture?: string | null;
-  applicationPreference?: ApplicationPreference;
   createdAt?: firebase.firestore.Timestamp;
 }
 
 export class User implements IUser {
   constructor(
     username: string,
+    applicationPreference?: ApplicationPreference | null,
     pinQuestionnaireRef: firebase.firestore.DocumentReference<
       firebase.firestore.DocumentData
     > | null = null,
@@ -54,7 +54,6 @@ export class User implements IUser {
     averageRating: number | null = 1,
     displayName: string | null = null,
     displayPicture: string | null = null,
-    applicationPreference = ApplicationPreference.pin,
     createdAt = firestore.Timestamp.now(),
   ) {
     this._cavQuestionnaireRef = cavQuestionnaireRef;
@@ -210,13 +209,13 @@ export class User implements IUser {
   }
 
   @IsEnum(ApplicationPreference)
-  private _applicationPreference: ApplicationPreference;
+  private _applicationPreference: ApplicationPreference | undefined | null;
 
-  get applicationPreference(): ApplicationPreference {
+  get applicationPreference(): ApplicationPreference | undefined | null {
     return this._applicationPreference;
   }
 
-  set applicationPreference(value: ApplicationPreference) {
+  set applicationPreference(value: ApplicationPreference | undefined | null) {
     this._applicationPreference = value;
   }
 
@@ -237,6 +236,7 @@ export class User implements IUser {
   static factory = (data: IUser): User =>
     new User(
       data.username,
+      data.applicationPreference,
       data.pinQuestionnaireRef,
       data.cavQuestionnaireRef,
       data.casesCompleted,
@@ -246,14 +246,13 @@ export class User implements IUser {
       data.averageRating,
       data.displayName,
       data.displayPicture,
-      data.applicationPreference,
       data.createdAt,
     );
 
   toObject(): object {
     return {
-      cavQuestionnaireRef: this.cavQuestionnaireRef?.path,
-      pinQuestionnaireRef: this.pinQuestionnaireRef?.path,
+      cavQuestionnaireRef: this.cavQuestionnaireRef?.path || null,
+      pinQuestionnaireRef: this.pinQuestionnaireRef?.path || null,
       username: this.username,
       casesCompleted: this.casesCompleted,
       requestsMade: this.requestsMade,
@@ -262,7 +261,7 @@ export class User implements IUser {
       averageRating: this.averageRating,
       displayName: this.displayName,
       displayPicture: this.displayPicture,
-      applicationPreference: this.applicationPreference,
+      applicationPreference: this.applicationPreference || null,
       createdAt: this.createdAt.toDate(),
     };
   }
@@ -272,18 +271,6 @@ export const UserFirestoreConverter: firebase.firestore.FirestoreDataConverter<U
   fromFirestore: (
     data: firebase.firestore.QueryDocumentSnapshot<IUser>,
   ): User => User.factory(data.data()),
-  toFirestore: (modelObject: User): firebase.firestore.DocumentData => ({
-    cavQuestionnaireRef: modelObject.cavQuestionnaireRef,
-    pinQuestionnaireRef: modelObject.pinQuestionnaireRef,
-    averageRating: modelObject.averageRating,
-    casesCompleted: modelObject.casesCompleted,
-    requestsMade: modelObject.requestsMade,
-    pinRatingsReceived: modelObject.pinRatingsReceived,
-    cavRatingsReceived: modelObject.cavRatingsReceived,
-    username: modelObject.username,
-    displayName: modelObject.displayName,
-    displayPicture: modelObject.displayPicture,
-    applicationPreference: modelObject.applicationPreference,
-    createdAt: modelObject.createdAt,
-  }),
+  toFirestore: (modelObject: User): firebase.firestore.DocumentData =>
+    modelObject.toObject(),
 };

--- a/web-client/src/models/users/index.ts
+++ b/web-client/src/models/users/index.ts
@@ -40,7 +40,7 @@ export interface IUser extends firebase.firestore.DocumentData {
 export class User implements IUser {
   constructor(
     username: string,
-    applicationPreference?: ApplicationPreference | null,
+    applicationPreference: ApplicationPreference | null = null,
     pinQuestionnaireRef: firebase.firestore.DocumentReference<
       firebase.firestore.DocumentData
     > | null = null,
@@ -261,7 +261,7 @@ export class User implements IUser {
       averageRating: this.averageRating,
       displayName: this.displayName,
       displayPicture: this.displayPicture,
-      applicationPreference: this.applicationPreference || null,
+      applicationPreference: this.applicationPreference,
       createdAt: this.createdAt.toDate(),
     };
   }

--- a/web-client/src/models/users/privilegedInformation.ts
+++ b/web-client/src/models/users/privilegedInformation.ts
@@ -133,8 +133,16 @@ export class PrivilegedUserInformation implements IPrivilegedUserInformation {
 
   toObject(): object {
     return {
-      addressFromGoogle: this.addressFromGoogle,
-      address: this.address,
+      addressFromGoogle: JSON.parse(JSON.stringify(this.addressFromGoogle)),
+      address: Object.keys(this.address).reduce((acc, key) => {
+        if (this.address[key]) {
+          return {
+            ...acc,
+            [key]: this.address[key],
+          };
+        }
+        return acc;
+      }, {}),
       sendNotifications: this.sendNotifications,
       privacyAccepted: this.privacyAccepted,
       privacyVersion: this.privacyVersion,
@@ -151,15 +159,5 @@ export const PrivilegedUserInformationFirestoreConverter: firebase.firestore.Fir
     PrivilegedUserInformation.factory(data.data()),
   toFirestore: (
     modelObject: PrivilegedUserInformation,
-  ): firebase.firestore.DocumentData => ({
-    addressFromGoogle: JSON.parse(
-      JSON.stringify(modelObject.addressFromGoogle),
-    ),
-    address: JSON.parse(JSON.stringify(modelObject.address)),
-    sendNotifications: modelObject.sendNotifications,
-    privacyAccepted: modelObject.privacyAccepted,
-    privacyVersion: modelObject.privacyVersion,
-    termsAccepted: modelObject.termsAccepted,
-    termsVersion: modelObject.termsVersion,
-  }),
+  ): firebase.firestore.DocumentData => modelObject.toObject(),
 };

--- a/web-client/src/modules/requests/containers/CompletedRequestsContainer/CompletedRequestsContainer.tsx
+++ b/web-client/src/modules/requests/containers/CompletedRequestsContainer/CompletedRequestsContainer.tsx
@@ -17,7 +17,11 @@ const CompletedRequestsContainer: React.FC = () => {
   );
 
   useEffect(() => {
-    if (profileState.profile && profileState.userRef) {
+    if (
+      profileState.profile &&
+      profileState.profile.applicationPreference &&
+      profileState.userRef
+    ) {
       return observeNonOpenRequests(dispatch, {
         userRef: profileState.userRef,
         userType: profileState.profile.applicationPreference,

--- a/web-client/src/modules/requests/containers/OngoingRequestsContainer/OngoingRequestsContainer.tsx
+++ b/web-client/src/modules/requests/containers/OngoingRequestsContainer/OngoingRequestsContainer.tsx
@@ -17,7 +17,11 @@ const OngoingRequestsContainer: React.FC = () => {
   );
 
   useEffect(() => {
-    if (profileState.profile && profileState.userRef) {
+    if (
+      profileState.profile &&
+      profileState.profile.applicationPreference &&
+      profileState.userRef
+    ) {
       return observeNonOpenRequests(dispatch, {
         userRef: profileState.userRef,
         userType: profileState.profile.applicationPreference,

--- a/web-client/src/modules/requests/containers/OpenRequestsContainer/OpenRequestsContainer.tsx
+++ b/web-client/src/modules/requests/containers/OpenRequestsContainer/OpenRequestsContainer.tsx
@@ -16,7 +16,7 @@ const OpenRequestsContainer: React.FC = () => {
   );
 
   useEffect(() => {
-    if (profileState.profile) {
+    if (profileState.profile && profileState.profile.applicationPreference) {
       return observeOpenRequests(dispatch, {
         userRef: profileState.userRef,
         userType: profileState.profile.applicationPreference,

--- a/web-client/src/modules/timeline/containers/TimelineViewContainer/TimelineViewContainer.tsx
+++ b/web-client/src/modules/timeline/containers/TimelineViewContainer/TimelineViewContainer.tsx
@@ -53,7 +53,11 @@ const TimelineViewContainer: React.FC<TimelineViewContainerProps> = ({
   }, [requestsState, requestId]);
 
   useEffect(() => {
-    if (profileState.profile && profileState.userRef) {
+    if (
+      profileState.profile &&
+      profileState.profile.applicationPreference &&
+      profileState.userRef
+    ) {
       const unsubscribeFromOpen = observeOpenRequests(dispatch, {
         userRef: profileState.userRef,
         userType: profileState.profile.applicationPreference,


### PR DESCRIPTION
## Description
This PR removes undefined attributes from the object to be sent to firestore without serializing and deserializing the object by using a reducer function.
This PR also removes the default assignment of the `applicationPreference` so that users are allowed to reach the `roleInfo` page and choose for themselves 

## Motivation
Firestore doesn't allow the value of an attribute to be `undefined`, the previous solution to fixing this error was to serialize the object into a string and then deserialize it into an object, thus removing all the `undefined` attributes. 
But this removed the properties of the `GeoPoint` data type and so the coordinates were saved as a `map` rather than `GeoPoint` on firestore.
This PR replaces the earlier approach with a reduce function.
## Testing Guidelines

## Release Checklist

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
