### PR TITLE
chore(web-client): remove model classes and class-validator

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -20,7 +20,6 @@
     "antd": "^4.0.4",
     "axios": "^0.19.2",
     "babel-plugin-import": "^1.13.0",
-    "class-validator": "^0.12.1",
     "customize-cra": "^0.9.1",
     "firebase": "^7.13.1",
     "formik": "^2.1.4",

--- a/web-client/src/ducks/offers/actions.ts
+++ b/web-client/src/ducks/offers/actions.ts
@@ -1,4 +1,4 @@
-import { IOffer, Offer } from 'src/models/offers';
+import { Offer } from 'src/models/offers';
 
 import {
   getRequestOffers as getRequestOffersFunc,
@@ -39,10 +39,7 @@ export const getRequestOffers = (payload: IgetRequestOffers) => (
     firebase: getRequestOffersFunc,
   });
 
-export const setOffer = (payload: IOffer) => (dispatch: Function) => {
-  const offerPayload = Offer.factory({
-    ...payload,
-  });
+export const setOffer = (offerPayload: Offer) => (dispatch: Function) => {
   dispatch({
     type: SET,
     payload: {

--- a/web-client/src/ducks/profile/actions.ts
+++ b/web-client/src/ducks/profile/actions.ts
@@ -1,6 +1,7 @@
 import firebase from 'src/firebase';
-import { User } from 'src/models/users';
+import { initUser, User } from 'src/models/users';
 import {
+  initPrivilegedUserInformation,
   IUserAddress,
   PrivilegedUserInformation,
 } from 'src/models/users/privilegedInformation';
@@ -75,24 +76,26 @@ export const setUserProfile = (
   uid: string,
   displayPic?: string | null,
 ) => (dispatch: Function) => {
-  const privilegedPayload = PrivilegedUserInformation.factory({
-    addressFromGoogle,
-    address,
-    // eslint-disable-next-line import/no-named-as-default-member
-    termsAccepted: firebase.firestore.Timestamp.fromDate(
-      termsAndPrivacyAccepted,
-    ),
-    termsVersion: '1.0',
-    // eslint-disable-next-line import/no-named-as-default-member
-    privacyAccepted: firebase.firestore.Timestamp.fromDate(
-      termsAndPrivacyAccepted,
-    ),
-    privacyVersion: '1.0',
-  });
-  const userPayload = User.factory({
+  const privilegedPayload: PrivilegedUserInformation = initPrivilegedUserInformation(
+    {
+      addressFromGoogle,
+      address,
+      // eslint-disable-next-line import/no-named-as-default-member
+      termsAccepted: firebase.firestore.Timestamp.fromDate(
+        termsAndPrivacyAccepted,
+      ),
+      termsVersion: '1.0',
+      // eslint-disable-next-line import/no-named-as-default-member
+      privacyAccepted: firebase.firestore.Timestamp.fromDate(
+        termsAndPrivacyAccepted,
+      ),
+      privacyVersion: '1.0',
+    },
+  );
+  const userPayload: User = initUser({
     username: displayName,
     displayName,
-    displayPicture: displayPic,
+    displayPicture: displayPic || null,
   });
   dispatch({
     type: SET,

--- a/web-client/src/ducks/requests/actions.ts
+++ b/web-client/src/ducks/requests/actions.ts
@@ -1,4 +1,4 @@
-import { IRequest, Request, RequestStatus } from 'src/models/requests';
+import { Request, RequestStatus } from 'src/models/requests';
 
 import {
   createUserRequest,
@@ -59,12 +59,9 @@ export const observeNonOpenRequests = (
     });
 };
 
-export const setRequest = (payload: IRequest, requestId?: string) => (
+export const setRequest = (requestPayload: Request, requestId?: string) => (
   dispatch: Function,
 ) => {
-  const requestPayload = Request.factory({
-    ...payload,
-  });
   dispatch({
     type: SET,
     payload: {

--- a/web-client/src/models/offers/index.ts
+++ b/web-client/src/models/offers/index.ts
@@ -1,14 +1,7 @@
-/* eslint no-underscore-dangle: 0 */
-import {
-  IsEnum,
-  IsNotEmpty,
-  IsObject,
-  IsString,
-  ValidateNested,
-} from 'class-validator';
 import { firestore } from 'firebase';
 
-import { IUser, User, UserFirestoreConverter } from '../users';
+import { User } from '../users';
+import { MakePartial } from '../util';
 
 export enum OfferStatus {
   pending = 'pending',
@@ -17,7 +10,7 @@ export enum OfferStatus {
   cavDeclined = 'cav_declined',
 }
 
-export interface IOffer extends firebase.firestore.DocumentData {
+export interface Offer {
   cavUserRef: firebase.firestore.DocumentReference<
     firebase.firestore.DocumentData
   >;
@@ -27,179 +20,22 @@ export interface IOffer extends firebase.firestore.DocumentData {
   requestRef: firebase.firestore.DocumentReference<
     firebase.firestore.DocumentData
   >;
-  cavUserSnapshot: IUser;
+  cavUserSnapshot: User;
   message: string;
   status: OfferStatus;
-  createdAt?: firebase.firestore.Timestamp;
+  createdAt: firebase.firestore.Timestamp;
 }
 
-export class Offer implements IOffer {
-  constructor(
-    cavUserRef: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-    pinUserRef: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-    requestRef: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-    cavUserSnapshot: User,
-    message: string,
-    status: OfferStatus,
-    createdAt = firestore.Timestamp.now(),
-  ) {
-    this._cavUserRef = cavUserRef;
-    this._pinUserRef = pinUserRef;
-    this._requestRef = requestRef;
-    this._cavUserSnapshot = cavUserSnapshot;
-    this._message = message;
-    this._status = status;
-    this._createdAt = createdAt;
-  }
-
-  @IsObject()
-  private _cavUserRef: firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  >;
-
-  get cavUserRef(): firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > {
-    return this._cavUserRef;
-  }
-
-  set cavUserRef(
-    value: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-  ) {
-    this._cavUserRef = value;
-  }
-
-  @IsObject()
-  private _pinUserRef: firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  >;
-
-  get pinUserRef(): firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > {
-    return this._pinUserRef;
-  }
-
-  set pinUserRef(
-    value: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-  ) {
-    this._pinUserRef = value;
-  }
-
-  @IsObject()
-  private _requestRef: firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  >;
-
-  get requestRef(): firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > {
-    return this._requestRef;
-  }
-
-  set requestRef(
-    value: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-  ) {
-    this._requestRef = value;
-  }
-
-  @ValidateNested()
-  private _cavUserSnapshot: User;
-
-  get cavUserSnapshot(): User {
-    return this._cavUserSnapshot;
-  }
-
-  set cavUserSnapshot(value: User) {
-    this._cavUserSnapshot = value;
-  }
-
-  @IsString()
-  @IsNotEmpty()
-  private _message: string;
-
-  get message(): string {
-    return this._message;
-  }
-
-  set message(value: string) {
-    this._message = value;
-  }
-
-  @IsEnum(OfferStatus)
-  private _status: OfferStatus;
-
-  get status(): OfferStatus {
-    return this._status;
-  }
-
-  set status(value: OfferStatus) {
-    this._status = value;
-  }
-
-  /* TODO: When we reach greater than 500 offers per request created per second:
-     https://firebase.google.com/docs/firestore/solutions/shard-timestamp#sharding_a_timestamp_field
-   */
-  @IsObject()
-  private _createdAt: firebase.firestore.Timestamp;
-
-  get createdAt(): firebase.firestore.Timestamp {
-    return this._createdAt;
-  }
-
-  set createdAt(value: firebase.firestore.Timestamp) {
-    this._createdAt = value;
-  }
-
-  static factory = (data: IOffer): Offer =>
-    new Offer(
-      data.cavUserRef,
-      data.pinUserRef,
-      data.requestRef,
-      User.factory(data.cavUserSnapshot),
-      data.message,
-      data.status,
-      data.createdAt,
-    );
-
-  toObject(): object {
-    return {
-      cavUserRef: this.cavUserRef.path,
-      pinUserRef: this.pinUserRef.path,
-      requestRef: this.requestRef.path,
-      cavUserSnapshot: User.factory(this.cavUserSnapshot),
-      message: this.message,
-      status: this.status,
-      createdAt: this.createdAt.toDate(),
-    };
-  }
-}
+/**
+ * Initialize with default values
+ */
+export const initOffer = (offer: MakePartial<Offer, 'createdAt'>): Offer => ({
+  createdAt: firestore.Timestamp.now(),
+  ...offer,
+});
 
 export const OfferFirestoreConverter: firebase.firestore.FirestoreDataConverter<Offer> = {
-  fromFirestore: (
-    data: firebase.firestore.QueryDocumentSnapshot<IOffer>,
-  ): Offer => Offer.factory(data.data()),
-  toFirestore: (modelObject: Offer): firebase.firestore.DocumentData => ({
-    cavUserRef: modelObject.cavUserRef,
-    pinUserRef: modelObject.pinUserRef,
-    requestRef: modelObject.requestRef,
-    cavUserSnapshot: UserFirestoreConverter.toFirestore(
-      modelObject.cavUserSnapshot,
-    ),
-    message: modelObject.message,
-    status: modelObject.status,
-    createdAt: modelObject.createdAt,
-  }),
+  fromFirestore: (data: firebase.firestore.QueryDocumentSnapshot<Offer>) =>
+    data.data(),
+  toFirestore: modelObject => modelObject,
 };

--- a/web-client/src/models/organizations/index.ts
+++ b/web-client/src/models/organizations/index.ts
@@ -1,6 +1,6 @@
-/* eslint no-underscore-dangle: 0 */
-import { IsArray, IsNotEmpty, IsObject, IsString } from 'class-validator';
 import { firestore } from 'firebase';
+
+import { MakePartial } from '../util';
 
 export enum OrganizationType {
   healthCare = 'health_care',
@@ -9,81 +9,25 @@ export enum OrganizationType {
   mutualAid = 'mutual_aid',
 }
 
-export interface IOrganization extends firebase.firestore.DocumentData {
+export interface Organization {
   name: string;
   types: OrganizationType[];
-  createdAt?: firebase.firestore.Timestamp;
+  createdAt: firebase.firestore.Timestamp;
 }
 
-export class Organization implements IOrganization {
-  constructor(
-    name: string,
-    types: OrganizationType[],
-    createdAt = firestore.Timestamp.now(),
-  ) {
-    this._name = name;
-    this._types = types;
-    this._createdAt = createdAt;
-  }
-
-  @IsString()
-  @IsNotEmpty()
-  private _name: string;
-
-  get name(): string {
-    return this._name;
-  }
-
-  set name(value: string) {
-    this._name = value;
-  }
-
-  @IsArray()
-  private _types: OrganizationType[];
-
-  get types(): OrganizationType[] {
-    return this._types;
-  }
-
-  set types(value: OrganizationType[]) {
-    this._types = value;
-  }
-
-  /* TODO: When we reach greater than 500 offers per request created per second:
-     https://firebase.google.com/docs/firestore/solutions/shard-timestamp#sharding_a_timestamp_field
-   */
-  @IsObject()
-  private _createdAt: firebase.firestore.Timestamp;
-
-  get createdAt(): firebase.firestore.Timestamp {
-    return this._createdAt;
-  }
-
-  set createdAt(value: firebase.firestore.Timestamp) {
-    this._createdAt = value;
-  }
-
-  static factory = (data: IOrganization): Organization =>
-    new Organization(data.name, data.types, data.createdAt);
-
-  toObject(): object {
-    return {
-      name: this.name,
-      types: this.types,
-      createdAt: this.createdAt.toDate(),
-    };
-  }
-}
+/**
+ * Initialize with default values
+ */
+export const initOrganization = (
+  org: MakePartial<Organization, 'createdAt'>,
+): Organization => ({
+  createdAt: firestore.Timestamp.now(),
+  ...org,
+});
 
 export const OrganizationFirestoreConverter: firebase.firestore.FirestoreDataConverter<Organization> = {
   fromFirestore: (
-    data: firebase.firestore.QueryDocumentSnapshot<IOrganization>,
-  ): Organization => Organization.factory(data.data()),
-  toFirestore: (
-    modelObject: Organization,
-  ): firebase.firestore.DocumentData => ({
-    name: modelObject.name,
-    types: modelObject.types,
-    createdAt: modelObject.createdAt,
-  }),
+    data: firebase.firestore.QueryDocumentSnapshot<Organization>,
+  ) => data.data(),
+  toFirestore: modelObject => modelObject,
 };

--- a/web-client/src/models/organizations/teams.ts
+++ b/web-client/src/models/organizations/teams.ts
@@ -1,82 +1,24 @@
-/* eslint no-underscore-dangle: 0 */
-import { IsArray, IsNotEmpty, IsObject, IsString } from 'class-validator';
 import { firestore } from 'firebase';
 
+import { MakePartial } from '../util';
 import { OrganizationType } from './index';
 
-export interface ITeam extends firebase.firestore.DocumentData {
+export interface Team {
   name: string;
   types: OrganizationType[];
-  createdAt?: firebase.firestore.Timestamp;
+  createdAt: firebase.firestore.Timestamp;
 }
 
-export class Team implements ITeam {
-  constructor(
-    name: string,
-    types: OrganizationType[],
-    createdAt = firestore.Timestamp.now(),
-  ) {
-    this._name = name;
-    this._types = types;
-    this._createdAt = createdAt;
-  }
-
-  @IsString()
-  @IsNotEmpty()
-  private _name: string;
-
-  get name(): string {
-    return this._name;
-  }
-
-  set name(value: string) {
-    this._name = value;
-  }
-
-  @IsArray()
-  private _types: OrganizationType[];
-
-  get types(): OrganizationType[] {
-    return this._types;
-  }
-
-  set types(value: OrganizationType[]) {
-    this._types = value;
-  }
-
-  /* TODO: When we reach greater than 500 offers per request created per second:
-     https://firebase.google.com/docs/firestore/solutions/shard-timestamp#sharding_a_timestamp_field
-   */
-  @IsObject()
-  private _createdAt: firebase.firestore.Timestamp;
-
-  get createdAt(): firebase.firestore.Timestamp {
-    return this._createdAt;
-  }
-
-  set createdAt(value: firebase.firestore.Timestamp) {
-    this._createdAt = value;
-  }
-
-  static factory = (data: ITeam): Team =>
-    new Team(data.name, data.types, data.createdAt);
-
-  toObject(): object {
-    return {
-      name: this.name,
-      types: this.types,
-      createdAt: this.createdAt.toDate(),
-    };
-  }
-}
+/**
+ * Initialize with default values
+ */
+export const initTeam = (team: MakePartial<Team, 'createdAt'>): Team => ({
+  createdAt: firestore.Timestamp.now(),
+  ...team,
+});
 
 export const TeamFirestoreConverter: firebase.firestore.FirestoreDataConverter<Team> = {
-  fromFirestore: (
-    data: firebase.firestore.QueryDocumentSnapshot<ITeam>,
-  ): Team => Team.factory(data.data()),
-  toFirestore: (modelObject: Team): firebase.firestore.DocumentData => ({
-    name: modelObject.name,
-    types: modelObject.types,
-    createdAt: modelObject.createdAt,
-  }),
+  fromFirestore: (data: firebase.firestore.QueryDocumentSnapshot<Team>) =>
+    data.data(),
+  toFirestore: modelObject => modelObject,
 };

--- a/web-client/src/models/questionnaires/index.ts
+++ b/web-client/src/models/questionnaires/index.ts
@@ -1,12 +1,6 @@
-/* eslint no-underscore-dangle: 0 */
-import {
-  IsEnum,
-  IsNotEmpty,
-  IsNotEmptyObject,
-  IsObject,
-  IsString,
-} from 'class-validator';
 import { firestore } from 'firebase';
+
+import { MakePartial } from '../util';
 
 export enum QuestionnaireType {
   pin = 'pin',
@@ -15,7 +9,7 @@ export enum QuestionnaireType {
   team = 'team',
 }
 
-export interface IQuestionnaire extends firebase.firestore.DocumentData {
+export interface Questionnaire {
   parentRef: firebase.firestore.DocumentReference<
     firebase.firestore.DocumentData
   >;
@@ -24,129 +18,22 @@ export interface IQuestionnaire extends firebase.firestore.DocumentData {
 
   type: QuestionnaireType;
   version: string;
-  createdAt?: firebase.firestore.Timestamp;
+  createdAt: firebase.firestore.Timestamp;
 }
 
-export class Questionnaire implements IQuestionnaire {
-  constructor(
-    parentRef: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data: { [p: string]: any },
-    type: QuestionnaireType,
-    version: string,
-    createdAt = firestore.Timestamp.now(),
-  ) {
-    this._parentRef = parentRef;
-    this._data = data;
-    this._type = type;
-    this._version = version;
-    this._createdAt = createdAt;
-  }
-
-  @IsNotEmptyObject()
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _parentRef: firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  >;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  get parentRef(): firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > {
-    return this._parentRef;
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  set parentRef(
-    value: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-  ) {
-    this._parentRef = value;
-  }
-
-  @IsNotEmptyObject()
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _data: { [p: string]: any };
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  get data(): { [p: string]: any } {
-    return this._data;
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  set data(value: { [p: string]: any }) {
-    this._data = value;
-  }
-
-  @IsEnum(QuestionnaireType)
-  private _type: QuestionnaireType;
-
-  get type(): QuestionnaireType {
-    return this._type;
-  }
-
-  set type(value: QuestionnaireType) {
-    this._type = value;
-  }
-
-  @IsString()
-  @IsNotEmpty()
-  private _version: string;
-
-  get version(): string {
-    return this._version;
-  }
-
-  set version(value: string) {
-    this._version = value;
-  }
-
-  @IsObject()
-  @IsNotEmptyObject()
-  private _createdAt: firebase.firestore.Timestamp;
-
-  get createdAt(): firebase.firestore.Timestamp {
-    return this._createdAt;
-  }
-
-  set createdAt(value: firebase.firestore.Timestamp) {
-    this._createdAt = value;
-  }
-
-  static factory = (data: IQuestionnaire): Questionnaire =>
-    new Questionnaire(
-      data.parentRef,
-      data.data,
-      data.type,
-      data.version,
-      data.createdAt,
-    );
-
-  toObject(): object {
-    return {
-      parentRef: this.parentRef.path,
-      data: this.data,
-      type: this.type,
-      version: this.version,
-      createdAt: this.createdAt.toDate(),
-    };
-  }
-}
+/**
+ * Initialize with default values
+ */
+export const initQuestionnaire = (
+  q: MakePartial<Questionnaire, 'createdAt'>,
+): Questionnaire => ({
+  createdAt: firestore.Timestamp.now(),
+  ...q,
+});
 
 export const QuestionnaireFirestoreConverter: firebase.firestore.FirestoreDataConverter<Questionnaire> = {
   fromFirestore: (
-    data: firebase.firestore.QueryDocumentSnapshot<IQuestionnaire>,
-  ): Questionnaire => Questionnaire.factory(data.data()),
-  toFirestore: (
-    modelObject: Questionnaire,
-  ): firebase.firestore.DocumentData => ({
-    parentRef: modelObject.parentRef,
-    data: modelObject.data,
-    type: modelObject.type,
-    createdAt: modelObject.createdAt,
-    version: modelObject.version,
-  }),
+    data: firebase.firestore.QueryDocumentSnapshot<Questionnaire>,
+  ) => data.data(),
+  toFirestore: modelObject => modelObject,
 };

--- a/web-client/src/models/requests/index.ts
+++ b/web-client/src/models/requests/index.ts
@@ -1,19 +1,7 @@
-/* eslint no-underscore-dangle: 0 */
-import {
-  Allow,
-  IsEnum,
-  IsInt,
-  IsNotEmpty,
-  IsNotEmptyObject,
-  IsObject,
-  IsString,
-  Max,
-  Min,
-  ValidateNested,
-} from 'class-validator';
 import { firestore } from 'firebase';
 
-import { IUser, User } from '../users';
+import { User } from '../users';
+import { MakePartial } from '../util';
 
 export enum RequestStatus {
   pending = 'pending',
@@ -23,291 +11,58 @@ export enum RequestStatus {
   removed = 'removed',
 }
 
-export interface IRequest extends firebase.firestore.DocumentData {
-  cavUserRef?: firebase.firestore.DocumentReference<
+export interface Request {
+  cavUserRef: firebase.firestore.DocumentReference<
     firebase.firestore.DocumentData
   > | null;
-  cavUserSnapshot?: IUser | null;
+  cavUserSnapshot: User | null;
   pinUserRef: firebase.firestore.DocumentReference<
     firebase.firestore.DocumentData
   >;
-  pinUserSnapshot: IUser;
+  pinUserSnapshot: User;
   title: string;
   description: string;
   latLng: firebase.firestore.GeoPoint;
-  status?: RequestStatus;
-  pinRating?: number | null;
-  cavRating?: number | null;
-  pinRatedAt?: firebase.firestore.Timestamp | null;
-  cavRatedAt?: firebase.firestore.Timestamp | null;
-  createdAt?: firebase.firestore.Timestamp;
-  updatedAt?: firebase.firestore.Timestamp;
+  status: RequestStatus;
+  pinRating: number | null;
+  cavRating: number | null;
+  pinRatedAt: firebase.firestore.Timestamp | null;
+  cavRatedAt: firebase.firestore.Timestamp | null;
+  createdAt: firebase.firestore.Timestamp;
+  updatedAt: firebase.firestore.Timestamp;
 }
 
-export class Request implements IRequest {
-  constructor(
-    pinUserRef: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-    pinUserSnapshot: User,
-    title: string,
-    description: string,
-    latLng: firebase.firestore.GeoPoint,
-    cavUserRef: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    > | null = null,
-    cavUserSnapshot: User | null = null,
-    status = RequestStatus.pending,
-    createdAt = firestore.Timestamp.now(),
-    updatedAt = firestore.Timestamp.now(),
-    pinRating: number | null = null,
-    cavRating: number | null = null,
-    pinRatedAt: firebase.firestore.Timestamp | null = null,
-    cavRatedAt: firebase.firestore.Timestamp | null = null,
-  ) {
-    this._cavUserRef = cavUserRef;
-    this._pinUserRef = pinUserRef;
-    this._pinUserSnapshot = pinUserSnapshot;
-    this._cavUserSnapshot = cavUserSnapshot;
-    this._title = title;
-    this._description = description;
-    this._latLng = latLng;
-    this._status = status;
-    this._createdAt = createdAt;
-    this._updatedAt = updatedAt;
-    this._pinRating = pinRating;
-    this._cavRating = cavRating;
-    this._pinRatedAt = pinRatedAt;
-    this._cavRatedAt = cavRatedAt;
-  }
+type RequestPropertiesWithDefaults =
+  | 'cavUserRef'
+  | 'cavUserSnapshot'
+  | 'status'
+  | 'pinRating'
+  | 'cavRating'
+  | 'pinRatedAt'
+  | 'cavRatedAt'
+  | 'createdAt'
+  | 'updatedAt';
 
-  @Allow()
-  private _cavUserRef: firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > | null;
-
-  get cavUserRef(): firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > | null {
-    return this._cavUserRef;
-  }
-
-  set cavUserRef(
-    value: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    > | null,
-  ) {
-    this._cavUserRef = value;
-  }
-
-  @IsNotEmptyObject()
-  private _pinUserRef: firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  >;
-
-  get pinUserRef(): firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > {
-    return this._pinUserRef;
-  }
-
-  set pinUserRef(
-    value: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    >,
-  ) {
-    this._pinUserRef = value;
-  }
-
-  @ValidateNested()
-  private _pinUserSnapshot: User;
-
-  get pinUserSnapshot(): User {
-    return this._pinUserSnapshot;
-  }
-
-  set pinUserSnapshot(value: User) {
-    this._pinUserSnapshot = value;
-  }
-
-  @ValidateNested()
-  private _cavUserSnapshot: User | null;
-
-  get cavUserSnapshot(): User | null {
-    return this._cavUserSnapshot;
-  }
-
-  set cavUserSnapshot(value: User | null) {
-    this._cavUserSnapshot = value;
-  }
-
-  @IsString()
-  @IsNotEmpty()
-  private _title: string;
-
-  get title(): string {
-    return this._title;
-  }
-
-  set title(value: string) {
-    this._title = value;
-  }
-
-  @IsString()
-  @IsNotEmpty()
-  private _description: string;
-
-  get description(): string {
-    return this._description;
-  }
-
-  set description(value: string) {
-    this._description = value;
-  }
-
-  @IsObject()
-  private _latLng: firebase.firestore.GeoPoint;
-
-  get latLng(): firebase.firestore.GeoPoint {
-    return this._latLng;
-  }
-
-  set latLng(value: firebase.firestore.GeoPoint) {
-    this._latLng = value;
-  }
-
-  @IsEnum(RequestStatus)
-  private _status: RequestStatus;
-
-  get status(): RequestStatus {
-    return this._status;
-  }
-
-  set status(value: RequestStatus) {
-    this._status = value;
-  }
-
-  /* TODO: When we reach greater than 500 requests created per second:
-     https://firebase.google.com/docs/firestore/solutions/shard-timestamp#sharding_a_timestamp_field
-   */
-  @IsObject()
-  private _createdAt: firebase.firestore.Timestamp;
-
-  get createdAt(): firebase.firestore.Timestamp {
-    return this._createdAt;
-  }
-
-  set createdAt(value: firebase.firestore.Timestamp) {
-    this._createdAt = value;
-  }
-
-  /* TODO: When we reach greater than 500 requests updated per second:
-     https://firebase.google.com/docs/firestore/solutions/shard-timestamp#sharding_a_timestamp_field
-   */
-  @IsObject()
-  private _updatedAt: firebase.firestore.Timestamp;
-
-  get updatedAt(): firebase.firestore.Timestamp {
-    return this._updatedAt;
-  }
-
-  set updatedAt(value: firebase.firestore.Timestamp) {
-    this._updatedAt = value;
-  }
-
-  @IsInt()
-  @Min(1)
-  @Max(5)
-  private _pinRating: number | null;
-
-  get pinRating(): number | null {
-    return this._pinRating;
-  }
-
-  set pinRating(value: number | null) {
-    this._pinRating = value;
-  }
-
-  @IsInt()
-  @Min(1)
-  @Max(5)
-  private _cavRating: number | null;
-
-  get cavRating(): number | null {
-    return this._cavRating;
-  }
-
-  set cavRating(value: number | null) {
-    this._cavRating = value;
-  }
-
-  @Allow()
-  private _pinRatedAt: firebase.firestore.Timestamp | null;
-
-  get pinRatedAt(): firebase.firestore.Timestamp | null {
-    return this._pinRatedAt;
-  }
-
-  set pinRatedAt(value: firebase.firestore.Timestamp | null) {
-    this._pinRatedAt = value;
-  }
-
-  @Allow()
-  private _cavRatedAt: firebase.firestore.Timestamp | null;
-
-  get cavRatedAt(): firebase.firestore.Timestamp | null {
-    return this._cavRatedAt;
-  }
-
-  set cavRatedAt(value: firebase.firestore.Timestamp | null) {
-    this._cavRatedAt = value;
-  }
-
-  static factory = (data: IRequest): Request =>
-    new Request(
-      data.pinUserRef,
-      User.factory(data.pinUserSnapshot),
-      data.title,
-      data.description,
-      data.latLng,
-      data.cavUserRef,
-      // This field may be null
-      data.cavUserSnapshot ? User.factory(data.cavUserSnapshot) : null,
-      data.status,
-      data.createdAt,
-      data.updatedAt,
-      data.pinRating,
-      data.cavRating,
-      data.pinRatedAt,
-      data.cavRatedAt,
-    );
-
-  toObject(): object {
-    return {
-      cavUserRef: this.cavUserRef?.path,
-      cavUserSnapshot: this.cavUserSnapshot
-        ? this.cavUserSnapshot.toObject()
-        : null,
-      pinUserRef: this.pinUserRef.path,
-      pinUserSnapshot: this.pinUserSnapshot.toObject(),
-      title: this.title,
-      description: this.description,
-      latLng: this.latLng,
-      status: this.status,
-      createdAt: this.createdAt.toDate(),
-      updatedAt: this.updatedAt.toDate(),
-      pinRating: this.pinRating,
-      cavRating: this.cavRating,
-      pinRatedAt: this.pinRatedAt?.toDate(),
-      cavRatedAt: this.cavRatedAt?.toDate(),
-    };
-  }
-}
+/**
+ * Initialize Request with default values
+ */
+export const initRequest = (
+  request: MakePartial<Request, RequestPropertiesWithDefaults>,
+): Request => ({
+  cavUserRef: null,
+  cavUserSnapshot: null,
+  status: RequestStatus.pending,
+  createdAt: firestore.Timestamp.now(),
+  updatedAt: firestore.Timestamp.now(),
+  pinRating: null,
+  cavRating: null,
+  pinRatedAt: null,
+  cavRatedAt: null,
+  ...request,
+});
 
 export const RequestFirestoreConverter: firebase.firestore.FirestoreDataConverter<Request> = {
-  fromFirestore: (
-    data: firebase.firestore.QueryDocumentSnapshot<IRequest>,
-  ): Request => Request.factory(data.data()),
-  toFirestore: (modelObject: Request): firebase.firestore.DocumentData =>
-    modelObject.toObject(),
+  fromFirestore: (data: firebase.firestore.QueryDocumentSnapshot<Request>) =>
+    data.data(),
+  toFirestore: (modelObject: Request) => modelObject,
 };

--- a/web-client/src/models/requests/privilegedInformation.ts
+++ b/web-client/src/models/requests/privilegedInformation.ts
@@ -1,50 +1,12 @@
-/* eslint no-underscore-dangle: 0 */
-import { IsObject } from 'class-validator';
-
-export interface IPrivilegedRequestInformation
-  extends firebase.firestore.DocumentData {
+export interface PrivilegedRequestInformation {
   address: google.maps.GeocoderResult;
-}
-
-export class PrivilegedRequestInformation
-  implements IPrivilegedRequestInformation {
-  constructor(address: google.maps.GeocoderResult) {
-    this._address = address;
-  }
-
-  @IsObject()
-  private _address: google.maps.GeocoderResult;
-
-  get address(): google.maps.GeocoderResult {
-    return this._address;
-  }
-
-  set address(value: google.maps.GeocoderResult) {
-    this._address = value;
-  }
-
-  static factory = (
-    data: IPrivilegedRequestInformation,
-  ): PrivilegedRequestInformation =>
-    new PrivilegedRequestInformation(data.address);
-
-  toObject(): object {
-    return {
-      address: this.address,
-    };
-  }
 }
 
 export const PrivilegedRequestInformationFirestoreConverter: firebase.firestore.FirestoreDataConverter<PrivilegedRequestInformation> = {
   fromFirestore: (
     data: firebase.firestore.QueryDocumentSnapshot<
-      IPrivilegedRequestInformation
+      PrivilegedRequestInformation
     >,
-  ): PrivilegedRequestInformation =>
-    PrivilegedRequestInformation.factory(data.data()),
-  toFirestore: (
-    modelObject: PrivilegedRequestInformation,
-  ): firebase.firestore.DocumentData => ({
-    address: modelObject.address,
-  }),
+  ) => data.data(),
+  toFirestore: modelObject => modelObject,
 };

--- a/web-client/src/models/requests/timeline.ts
+++ b/web-client/src/models/requests/timeline.ts
@@ -1,89 +1,21 @@
-/* eslint no-underscore-dangle: 0 */
-import { IsObject } from 'class-validator';
 import { firestore } from 'firebase';
 
-import { IOffer } from '../offers';
-import { IRequest } from './index';
+import { Offer } from '../offers';
+import { MakePartial } from '../util';
+import { Request } from './index';
 
-export interface ITimelineItem extends firebase.firestore.DocumentData {
-  offerSnapshot: IOffer;
-  requestSnapshot: IRequest;
-  createdAt?: firebase.firestore.Timestamp;
+export interface TimelineItem {
+  offerSnapshot: Offer;
+  requestSnapshot: Request;
+  createdAt: firebase.firestore.Timestamp;
 }
 
 /**
- * Cannot be created/modified/deleted by a User. This is audit log maintained by the system
- * It is used to render a timeline of the request on the front end, but all records
- * are created automatically by the system based on status changes.
+ * Initialize with default values
  */
-export class TimelineItem
-  implements
-    ITimelineItem,
-    firebase.firestore.FirestoreDataConverter<TimelineItem> {
-  @IsObject()
-  private _offerSnapshot: IOffer;
-
-  @IsObject()
-  private _requestSnapshot: IRequest;
-
-  @IsObject()
-  private _createdAt: firebase.firestore.Timestamp;
-
-  constructor(
-    offerSnapshot: IOffer,
-    requestSnapshot: IRequest,
-    createdAt = firestore.Timestamp.now(),
-  ) {
-    this._offerSnapshot = offerSnapshot;
-    this._requestSnapshot = requestSnapshot;
-    this._createdAt = createdAt;
-  }
-
-  static factory(data: ITimelineItem): TimelineItem {
-    return new TimelineItem(
-      data.offerSnapshot,
-      data.requestSnapshot,
-      data.createdAt || firestore.Timestamp.now(),
-    );
-  }
-
-  get offerSnapshot(): IOffer {
-    return this._offerSnapshot;
-  }
-
-  set offerSnapshot(value: IOffer) {
-    this._offerSnapshot = value;
-  }
-
-  get requestSnapshot(): IRequest {
-    return this._requestSnapshot;
-  }
-
-  set requestSnapshot(value: IRequest) {
-    this._requestSnapshot = value;
-  }
-
-  get createdAt(): firebase.firestore.Timestamp {
-    return this._createdAt;
-  }
-
-  set createdAt(value: firebase.firestore.Timestamp) {
-    this._createdAt = value;
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  fromFirestore(
-    data: firebase.firestore.QueryDocumentSnapshot<ITimelineItem>,
-  ): TimelineItem {
-    return TimelineItem.factory(data.data());
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  toFirestore(modelObject: TimelineItem): ITimelineItem {
-    return {
-      offerSnapshot: modelObject.offerSnapshot,
-      requestSnapshot: modelObject.requestSnapshot,
-      createdAt: modelObject._createdAt,
-    };
-  }
-}
+export const initTimelineItem = (
+  t: MakePartial<TimelineItem, 'createdAt'>,
+): TimelineItem => ({
+  createdAt: firestore.Timestamp.now(),
+  ...t,
+});

--- a/web-client/src/models/users/index.ts
+++ b/web-client/src/models/users/index.ts
@@ -1,276 +1,66 @@
-/* eslint no-underscore-dangle: 0 */
-import {
-  IsEnum,
-  IsInt,
-  IsNotEmpty,
-  IsNumber,
-  IsObject,
-  IsOptional,
-  IsString,
-  IsUrl,
-  Max,
-  Min,
-} from 'class-validator';
 import { firestore } from 'firebase';
+
+import { MakePartial } from '../util';
 
 export enum ApplicationPreference {
   pin = 'pin',
   cav = 'cav',
 }
 
-export interface IUser extends firebase.firestore.DocumentData {
+export interface User {
   username: string;
-  applicationPreference?: ApplicationPreference | null;
-  cavQuestionnaireRef?: firebase.firestore.DocumentReference<
+  applicationPreference: ApplicationPreference | null;
+  cavQuestionnaireRef: firebase.firestore.DocumentReference<
     firebase.firestore.DocumentData
   > | null;
-  pinQuestionnaireRef?: firebase.firestore.DocumentReference<
+  pinQuestionnaireRef: firebase.firestore.DocumentReference<
     firebase.firestore.DocumentData
   > | null;
-  averageRating?: number | null;
-  casesCompleted?: number;
-  requestsMade?: number;
-  pinRatingsReceived?: number;
-  cavRatingsReceived?: number;
-  displayName?: string | null;
-  displayPicture?: string | null;
-  createdAt?: firebase.firestore.Timestamp;
+  averageRating: number | null;
+  casesCompleted: number;
+  requestsMade: number;
+  pinRatingsReceived: number;
+  cavRatingsReceived: number;
+  displayName: string | null;
+  displayPicture: string | null;
+  createdAt: firebase.firestore.Timestamp;
 }
 
-export class User implements IUser {
-  constructor(
-    username: string,
-    applicationPreference: ApplicationPreference | null = null,
-    pinQuestionnaireRef: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    > | null = null,
-    cavQuestionnaireRef: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    > | null = null,
-    casesCompleted = 0,
-    requestsMade = 0,
-    pinRatingsReceived = 0,
-    cavRatingsReceived = 0,
-    averageRating: number | null = 1,
-    displayName: string | null = null,
-    displayPicture: string | null = null,
-    createdAt = firestore.Timestamp.now(),
-  ) {
-    this._cavQuestionnaireRef = cavQuestionnaireRef;
-    this._pinQuestionnaireRef = pinQuestionnaireRef;
-    this._averageRating = averageRating;
-    this._casesCompleted = casesCompleted;
-    this._requestsMade = requestsMade;
-    this._pinRatingsReceived = pinRatingsReceived;
-    this._cavRatingsReceived = cavRatingsReceived;
-    this._username = username;
-    this._displayName = displayName;
-    this._displayPicture = displayPicture;
-    this._applicationPreference = applicationPreference;
-    this._createdAt = createdAt;
-  }
+type UserPropertiesWithDefaults =
+  | 'applicationPreference'
+  | 'pinQuestionnaireRef'
+  | 'cavQuestionnaireRef'
+  | 'casesCompleted'
+  | 'requestsMade'
+  | 'pinRatingsReceived'
+  | 'cavRatingsReceived'
+  | 'averageRating'
+  | 'displayName'
+  | 'displayPicture'
+  | 'createdAt';
 
-  @IsObject()
-  @IsOptional()
-  private _cavQuestionnaireRef: firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > | null;
-
-  get cavQuestionnaireRef(): firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > | null {
-    return this._cavQuestionnaireRef;
-  }
-
-  set cavQuestionnaireRef(
-    value: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    > | null,
-  ) {
-    this._cavQuestionnaireRef = value;
-  }
-
-  @IsObject()
-  @IsOptional()
-  private _pinQuestionnaireRef: firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > | null;
-
-  get pinQuestionnaireRef(): firebase.firestore.DocumentReference<
-    firebase.firestore.DocumentData
-  > | null {
-    return this._pinQuestionnaireRef;
-  }
-
-  set pinQuestionnaireRef(
-    value: firebase.firestore.DocumentReference<
-      firebase.firestore.DocumentData
-    > | null,
-  ) {
-    this._pinQuestionnaireRef = value;
-  }
-
-  @IsNumber()
-  @Min(1)
-  @Max(5)
-  @IsOptional()
-  private _averageRating: number | null;
-
-  get averageRating(): number | null {
-    return this._averageRating;
-  }
-
-  set averageRating(value: number | null) {
-    this._averageRating = value;
-  }
-
-  @IsInt()
-  @Min(0)
-  private _casesCompleted: number;
-
-  get casesCompleted(): number {
-    return this._casesCompleted;
-  }
-
-  set casesCompleted(value: number) {
-    this._casesCompleted = value;
-  }
-
-  @IsInt()
-  @Min(0)
-  private _requestsMade: number;
-
-  get requestsMade(): number {
-    return this._requestsMade;
-  }
-
-  set requestsMade(value: number) {
-    this._requestsMade = value;
-  }
-
-  @IsInt()
-  @Min(0)
-  private _pinRatingsReceived: number;
-
-  get pinRatingsReceived(): number {
-    return this._pinRatingsReceived;
-  }
-
-  set pinRatingsReceived(value: number) {
-    this._pinRatingsReceived = value;
-  }
-
-  @IsInt()
-  @Min(0)
-  private _cavRatingsReceived: number;
-
-  get cavRatingsReceived(): number {
-    return this._cavRatingsReceived;
-  }
-
-  set cavRatingsReceived(value: number) {
-    this._cavRatingsReceived = value;
-  }
-
-  @IsString()
-  @IsNotEmpty()
-  private _username: string;
-
-  get username(): string {
-    return this._username;
-  }
-
-  set username(value: string) {
-    this._username = value;
-  }
-
-  @IsString()
-  @IsOptional()
-  private _displayName: string | null;
-
-  get displayName(): string | null {
-    return this._displayName;
-  }
-
-  set displayName(value: string | null) {
-    this._displayName = value;
-  }
-
-  @IsUrl()
-  @IsOptional()
-  private _displayPicture: string | null;
-
-  get displayPicture(): string | null {
-    return this._displayPicture;
-  }
-
-  set displayPicture(value: string | null) {
-    this._displayPicture = value;
-  }
-
-  @IsEnum(ApplicationPreference)
-  private _applicationPreference: ApplicationPreference | undefined | null;
-
-  get applicationPreference(): ApplicationPreference | undefined | null {
-    return this._applicationPreference;
-  }
-
-  set applicationPreference(value: ApplicationPreference | undefined | null) {
-    this._applicationPreference = value;
-  }
-
-  /* TODO: When we reach greater than 500 offers per request created per second:
-     https://firebase.google.com/docs/firestore/solutions/shard-timestamp#sharding_a_timestamp_field
-   */
-  @IsObject()
-  private _createdAt: firebase.firestore.Timestamp;
-
-  get createdAt(): firebase.firestore.Timestamp {
-    return this._createdAt;
-  }
-
-  set createdAt(value: firebase.firestore.Timestamp) {
-    this._createdAt = value;
-  }
-
-  static factory = (data: IUser): User =>
-    new User(
-      data.username,
-      data.applicationPreference,
-      data.pinQuestionnaireRef,
-      data.cavQuestionnaireRef,
-      data.casesCompleted,
-      data.requestsMade,
-      data.pinRatingsReceived,
-      data.cavRatingsReceived,
-      data.averageRating,
-      data.displayName,
-      data.displayPicture,
-      data.createdAt,
-    );
-
-  toObject(): object {
-    return {
-      cavQuestionnaireRef: this.cavQuestionnaireRef?.path || null,
-      pinQuestionnaireRef: this.pinQuestionnaireRef?.path || null,
-      username: this.username,
-      casesCompleted: this.casesCompleted,
-      requestsMade: this.requestsMade,
-      pinRatingsReceived: this.pinRatingsReceived,
-      cavRatingsReceived: this.cavRatingsReceived,
-      averageRating: this.averageRating,
-      displayName: this.displayName,
-      displayPicture: this.displayPicture,
-      applicationPreference: this.applicationPreference,
-      createdAt: this.createdAt.toDate(),
-    };
-  }
-}
+/**
+ * Initialize Request with default values
+ */
+export const initUser = (
+  user: MakePartial<User, UserPropertiesWithDefaults>,
+): User => ({
+  applicationPreference: null,
+  pinQuestionnaireRef: null,
+  cavQuestionnaireRef: null,
+  casesCompleted: 0,
+  requestsMade: 0,
+  pinRatingsReceived: 0,
+  cavRatingsReceived: 0,
+  averageRating: 1,
+  displayName: null,
+  displayPicture: null,
+  createdAt: firestore.Timestamp.now(),
+  ...user,
+});
 
 export const UserFirestoreConverter: firebase.firestore.FirestoreDataConverter<User> = {
-  fromFirestore: (
-    data: firebase.firestore.QueryDocumentSnapshot<IUser>,
-  ): User => User.factory(data.data()),
-  toFirestore: (modelObject: User): firebase.firestore.DocumentData =>
-    modelObject.toObject(),
+  fromFirestore: (data: firebase.firestore.QueryDocumentSnapshot<User>) =>
+    data.data(),
+  toFirestore: modelObject => modelObject,
 };

--- a/web-client/src/models/users/privilegedInformation.ts
+++ b/web-client/src/models/users/privilegedInformation.ts
@@ -1,5 +1,4 @@
-/* eslint no-underscore-dangle: 0 */
-import { IsBoolean, IsObject, IsString } from 'class-validator';
+import { MakePartial } from '../util';
 
 export interface IUserAddress {
   address1?: string;
@@ -11,153 +10,29 @@ export interface IUserAddress {
   coords: firebase.firestore.GeoPoint;
 }
 
-export interface IPrivilegedUserInformation
-  extends firebase.firestore.DocumentData {
+export interface PrivilegedUserInformation {
   addressFromGoogle: google.maps.GeocoderResult;
   address: IUserAddress;
-  sendNotifications?: boolean;
+  sendNotifications: boolean;
   termsAccepted: firebase.firestore.Timestamp; // acts as a timestamp of when and as a boolean: if accepted it exists.
   termsVersion: string;
   privacyAccepted: firebase.firestore.Timestamp; // acts as a timestamp of when and as a boolean: if accepted it exists.
   privacyVersion: string;
 }
 
-export class PrivilegedUserInformation implements IPrivilegedUserInformation {
-  constructor(
-    addressFromGoogle: google.maps.GeocoderResult,
-    address: IUserAddress,
-    privacyAccepted: firebase.firestore.Timestamp,
-    privacyVersion: string,
-    termsAccepted: firebase.firestore.Timestamp,
-    termsVersion: string,
-    sendNotificatoins = false,
-  ) {
-    this._addressFromGoogle = addressFromGoogle;
-    this._address = address;
-    this._sendNotifications = sendNotificatoins;
-    this._privacyAccepted = privacyAccepted;
-    this._privacyVersion = privacyVersion;
-    this._termsAccepted = termsAccepted;
-    this._termsVersion = termsVersion;
-  }
-
-  @IsObject()
-  private _addressFromGoogle: google.maps.GeocoderResult;
-
-  get addressFromGoogle(): google.maps.GeocoderResult {
-    return this._addressFromGoogle;
-  }
-
-  set addressFromGoogle(value: google.maps.GeocoderResult) {
-    this._addressFromGoogle = value;
-  }
-
-  @IsObject()
-  private _address: IUserAddress;
-
-  get address(): IUserAddress {
-    return this._address;
-  }
-
-  set address(value: IUserAddress) {
-    this._address = value;
-  }
-
-  @IsBoolean()
-  private _sendNotifications: boolean;
-
-  get sendNotifications(): boolean {
-    return this._sendNotifications;
-  }
-
-  set sendNotifications(value: boolean) {
-    this._sendNotifications = value;
-  }
-
-  @IsObject()
-  private _privacyAccepted: firebase.firestore.Timestamp;
-
-  get privacyAccepted(): firebase.firestore.Timestamp {
-    return this._privacyAccepted;
-  }
-
-  set privacyAccepted(value: firebase.firestore.Timestamp) {
-    this._privacyAccepted = value;
-  }
-
-  @IsString()
-  private _privacyVersion: string;
-
-  get privacyVersion(): string {
-    return this._privacyVersion;
-  }
-
-  set privacyVersion(value: string) {
-    this._privacyVersion = value;
-  }
-
-  @IsObject()
-  private _termsAccepted: firebase.firestore.Timestamp;
-
-  get termsAccepted(): firebase.firestore.Timestamp {
-    return this._termsAccepted;
-  }
-
-  set termsAccepted(value: firebase.firestore.Timestamp) {
-    this._termsAccepted = value;
-  }
-
-  @IsString()
-  private _termsVersion: string;
-
-  get termsVersion(): string {
-    return this._termsVersion;
-  }
-
-  set termsVersion(value: string) {
-    this._termsVersion = value;
-  }
-
-  static factory = (
-    data: IPrivilegedUserInformation,
-  ): PrivilegedUserInformation =>
-    new PrivilegedUserInformation(
-      data.addressFromGoogle,
-      data.address,
-      data.privacyAccepted,
-      data.privacyVersion,
-      data.termsAccepted,
-      data.termsVersion,
-      data.sendNotifications,
-    );
-
-  toObject(): object {
-    return {
-      addressFromGoogle: JSON.parse(JSON.stringify(this.addressFromGoogle)),
-      address: Object.keys(this.address).reduce((acc, key) => {
-        if (this.address[key]) {
-          return {
-            ...acc,
-            [key]: this.address[key],
-          };
-        }
-        return acc;
-      }, {}),
-      sendNotifications: this.sendNotifications,
-      privacyAccepted: this.privacyAccepted,
-      privacyVersion: this.privacyVersion,
-      termsAccepted: this.termsAccepted,
-      termsVersion: this.termsVersion,
-    };
-  }
-}
+/**
+ * Initialize with default values
+ */
+export const initPrivilegedUserInformation = (
+  info: MakePartial<PrivilegedUserInformation, 'sendNotifications'>,
+): PrivilegedUserInformation => ({
+  sendNotifications: false,
+  ...info,
+});
 
 export const PrivilegedUserInformationFirestoreConverter: firebase.firestore.FirestoreDataConverter<PrivilegedUserInformation> = {
   fromFirestore: (
-    data: firebase.firestore.QueryDocumentSnapshot<IPrivilegedUserInformation>,
-  ): PrivilegedUserInformation =>
-    PrivilegedUserInformation.factory(data.data()),
-  toFirestore: (
-    modelObject: PrivilegedUserInformation,
-  ): firebase.firestore.DocumentData => modelObject.toObject(),
+    data: firebase.firestore.QueryDocumentSnapshot<PrivilegedUserInformation>,
+  ) => data.data(),
+  toFirestore: modelObject => modelObject,
 };

--- a/web-client/src/models/util.ts
+++ b/web-client/src/models/util.ts
@@ -1,0 +1,5 @@
+/**
+ * Make the properties K optional in type T
+ */
+export type MakePartial<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>> &
+  Partial<Pick<T, K>>;

--- a/web-client/src/modules/requests/containers/OpenRequestsContainer/OpenRequestsContainer.tsx
+++ b/web-client/src/modules/requests/containers/OpenRequestsContainer/OpenRequestsContainer.tsx
@@ -7,7 +7,7 @@ import { ProfileState } from 'src/ducks/profile/types';
 import { observeOpenRequests } from 'src/ducks/requests/actions';
 import { RequestState } from 'src/ducks/requests/types';
 import { firestore } from 'src/firebase';
-import { OfferStatus } from 'src/models/offers';
+import { initOffer, OfferStatus } from 'src/models/offers';
 import { Request } from 'src/models/requests';
 import { ApplicationPreference } from 'src/models/users';
 import { TimelineViewLocation } from 'src/modules/timeline/pages/routes/TimelineViewRoute/constants';
@@ -94,14 +94,16 @@ const OpenRequestsContainer: React.FC = () => {
       profileState.profile.applicationPreference === ApplicationPreference.cav
     ) {
       dispatch(
-        setOffer({
-          cavUserRef: profileState.userRef,
-          pinUserRef: openRequests.data[id].pinUserRef,
-          requestRef: firestore.collection('requests').doc(id),
-          cavUserSnapshot: profileState.profile,
-          message: 'I want to help!',
-          status: action ? OfferStatus.pending : OfferStatus.cavDeclined,
-        }),
+        setOffer(
+          initOffer({
+            cavUserRef: profileState.userRef,
+            pinUserRef: openRequests.data[id].pinUserRef,
+            requestRef: firestore.collection('requests').doc(id),
+            cavUserSnapshot: profileState.profile,
+            message: 'I want to help!',
+            status: action ? OfferStatus.pending : OfferStatus.cavDeclined,
+          }),
+        ),
       );
     }
   };

--- a/web-client/src/pages/MasterPage.tsx
+++ b/web-client/src/pages/MasterPage.tsx
@@ -12,7 +12,7 @@ import { updateUserPrivilegedInformation } from 'src/ducks/profile/actions';
 import { ProfileState } from 'src/ducks/profile/types';
 import { changeModal, setRequest } from 'src/ducks/requests/actions';
 import { RequestState } from 'src/ducks/requests/types';
-import { IUser } from 'src/models/users';
+import { initRequest, RequestStatus } from 'src/models/requests';
 import { OpenRequestsLocation } from 'src/modules/requests/pages/routes/OpenRequestsRoute/constants';
 
 import modules from '../modules';
@@ -42,13 +42,16 @@ const MasterPage = (): ReactElement => {
       profileState.privilegedInformation
     ) {
       dispatch(
-        setRequest({
-          title,
-          description: body,
-          pinUserRef: profileState.userRef,
-          pinUserSnapshot: profileState.profile.toObject() as IUser,
-          latLng: profileState.privilegedInformation.address.coords,
-        }),
+        setRequest(
+          initRequest({
+            title,
+            description: body,
+            pinUserRef: profileState.userRef,
+            pinUserSnapshot: profileState.profile,
+            latLng: profileState.privilegedInformation.address.coords,
+            status: RequestStatus.pending,
+          }),
+        ),
       );
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,11 +2951,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/validator@13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.0.0.tgz#365f1bf936aeaddd0856fc41aa1d6f82d88ee5b3"
-  integrity sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==
-
 "@types/vfile-message@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"
@@ -5353,15 +5348,6 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
-
-class-validator@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.12.1.tgz#9e89a9b7e8288ac07e0b9f5586cc089369d22790"
-  integrity sha512-vdhhOk3Juyu1EAyvka0K0rZjwGJf0JJqAeoBkLG0oSHp73HYcELwumHRHGhxydJIhg+qO81HkqrZiC39aajetw==
-  dependencies:
-    "@types/validator" "13.0.0"
-    google-libphonenumber "^3.2.8"
-    validator "13.0.0"
 
 classnames@2.x, classnames@^2.2.0, classnames@^2.2.1, classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6, classnames@~2.2.6:
   version "2.2.6"
@@ -9992,11 +9978,6 @@ google-gax@~1.12.0:
     retry-request "^4.0.0"
     semver "^6.0.0"
     walkdir "^0.4.0"
-
-google-libphonenumber@^3.2.8:
-  version "3.2.8"
-  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.8.tgz#fb5898cbae18104d456e0fd80df52d860a3eb2b8"
-  integrity sha512-iWs1KcxOozmKQbCeGjvU0M7urrkNjBYOSBtb819RjkUNJHJLfn7DADKkKwdJTOMPLcLOE11/4h/FyFwJsTiwLg==
 
 google-map-react@^1.1.7:
   version "1.1.7"
@@ -21822,11 +21803,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-validator@13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-13.0.0.tgz#0fb6c6bb5218ea23d368a8347e6d0f5a70e3bcab"
-  integrity sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description

With the exception of default values,
the functionality of these classes (i.e. data validation) is not
being used at all in the web-client code, so we can just use the
model interfaces and data objects directly.

For default values, I've introduced the concept of "init"
functions that allow some properties to be made optional,
which means it will now be explicit throughout the
codebase which objects are fully-initialized documents,
and which are partial.

Functionality *should* hopefully remain the same after this change.

## Motivation

* Reduces the amount of code for the models considerably
* Removes functionality that wasn't being used (class validation decorators), and which was likely to be out-of-sync with the interfaces.
* Makes it explicit when we're augmenting a partial document with default values (rather than implicitly relying on class constructors to do this). I.e using the `init*()` functions.
* Reduces the amount of code that has to be migrated to the `model` package, making that migration simpler.
