### PR TITLE
moved the opt-in for emails and notifications to the personal data and model updates

### DIFF
--- a/functions/src/models/users/privilegedInformation.ts
+++ b/functions/src/models/users/privilegedInformation.ts
@@ -1,5 +1,5 @@
 import { firestore } from 'firebase';
-import { IsObject, IsString } from 'class-validator';
+import { IsObject, IsOptional, IsString } from 'class-validator';
 
 import { FirestoreDataConverter } from '@google-cloud/firestore';
 import Timestamp = firestore.Timestamp;
@@ -23,7 +23,7 @@ export interface IPrivilegedUserInformation extends DocumentData {
   termsVersion: string;
   privacyAccepted: Timestamp; // acts as a timestamp of when and as a boolean: if accepted it exists.
   privacyVersion: string;
-  sendNotifications: Timestamp; // acts as a timestamp of when and as a boolean: if accepted it exists.
+  sendNotifications: Timestamp | null; // acts as a timestamp of when and as a boolean: if accepted it exists.
 }
 
 export class PrivilegedUserInformation implements IPrivilegedUserInformation {
@@ -34,7 +34,7 @@ export class PrivilegedUserInformation implements IPrivilegedUserInformation {
     privacyVersion: string,
     termsAccepted: Timestamp,
     termsVersion: string,
-    sendNotifications: Timestamp,
+    sendNotifications: Timestamp | null,
   ) {
     this._addressFromGoogle = addressFromGoogle;
     this._address = address;
@@ -112,13 +112,14 @@ export class PrivilegedUserInformation implements IPrivilegedUserInformation {
   }
 
   @IsObject()
-  private _sendNotifications: Timestamp;
+  @IsOptional()
+  private _sendNotifications: Timestamp | null;
 
-  get sendNotifications(): Timestamp {
+  get sendNotifications(): Timestamp | null {
     return this._sendNotifications;
   }
 
-  set sendNotifications(value: Timestamp) {
+  set sendNotifications(value: Timestamp | null) {
     this._sendNotifications = value;
   }
 

--- a/web-client/src/ducks/profile/actions.ts
+++ b/web-client/src/ducks/profile/actions.ts
@@ -73,6 +73,7 @@ export const setUserProfile = (
   termsAndPrivacyAccepted: Date,
   displayName: string,
   uid: string,
+  sendNotifications: firebase.firestore.Timestamp | null,
   displayPic?: string | null,
 ) => (dispatch: Function) => {
   const privilegedPayload = PrivilegedUserInformation.factory({
@@ -88,6 +89,7 @@ export const setUserProfile = (
       termsAndPrivacyAccepted,
     ),
     privacyVersion: '1.0',
+    sendNotifications,
   });
   const userPayload = User.factory({
     username: displayName,

--- a/web-client/src/models/users/privilegedInformation.ts
+++ b/web-client/src/models/users/privilegedInformation.ts
@@ -1,5 +1,5 @@
 /* eslint no-underscore-dangle: 0 */
-import { IsBoolean, IsObject, IsString } from 'class-validator';
+import { IsObject, IsString } from 'class-validator';
 
 export interface IUserAddress {
   address1?: string;
@@ -15,7 +15,7 @@ export interface IPrivilegedUserInformation
   extends firebase.firestore.DocumentData {
   addressFromGoogle: google.maps.GeocoderResult;
   address: IUserAddress;
-  sendNotifications?: boolean;
+  sendNotifications?: firebase.firestore.Timestamp | null;
   termsAccepted: firebase.firestore.Timestamp; // acts as a timestamp of when and as a boolean: if accepted it exists.
   termsVersion: string;
   privacyAccepted: firebase.firestore.Timestamp; // acts as a timestamp of when and as a boolean: if accepted it exists.
@@ -30,7 +30,7 @@ export class PrivilegedUserInformation implements IPrivilegedUserInformation {
     privacyVersion: string,
     termsAccepted: firebase.firestore.Timestamp,
     termsVersion: string,
-    sendNotificatoins = false,
+    sendNotificatoins: firebase.firestore.Timestamp | null = null,
   ) {
     this._addressFromGoogle = addressFromGoogle;
     this._address = address;
@@ -63,14 +63,14 @@ export class PrivilegedUserInformation implements IPrivilegedUserInformation {
     this._address = value;
   }
 
-  @IsBoolean()
-  private _sendNotifications: boolean;
+  @IsObject()
+  private _sendNotifications: firebase.firestore.Timestamp | null;
 
-  get sendNotifications(): boolean {
+  get sendNotifications(): firebase.firestore.Timestamp | null {
     return this._sendNotifications;
   }
 
-  set sendNotifications(value: boolean) {
+  set sendNotifications(value: firebase.firestore.Timestamp | null) {
     this._sendNotifications = value;
   }
 

--- a/web-client/src/modules/personalData/components/PersonalDataForm/PersonalDataForm.tsx
+++ b/web-client/src/modules/personalData/components/PersonalDataForm/PersonalDataForm.tsx
@@ -72,6 +72,7 @@ export interface IPersonalData {
   displayPic?: string | null;
   termsAndPrivacyAccepted?: Date;
   address: IUserAddress;
+  sendNotificatoins: firebase.firestore.Timestamp | null;
 }
 
 const PersonalDataForm: React.FC<PersonalDataFormProps> = ({
@@ -99,6 +100,9 @@ const PersonalDataForm: React.FC<PersonalDataFormProps> = ({
     string | undefined | null
   >(undefined);
   const [acceptToUsePhoto, setAcceptToUsePhoto] = useState<boolean>(true);
+  const [allowSendNotifications, setAllowSendNotifications] = useState<boolean>(
+    false,
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
   const [instructionsVisible, setInstructionsVisible] = useState(false);
@@ -253,6 +257,9 @@ const PersonalDataForm: React.FC<PersonalDataFormProps> = ({
       if (addressToSet.coords) {
         setCoords(addressToSet.coords);
       }
+      if (privilegedInfo.sendNotifications) {
+        setAllowSendNotifications(true);
+      }
     }
   }, [
     user,
@@ -290,6 +297,7 @@ const PersonalDataForm: React.FC<PersonalDataFormProps> = ({
       displayPic,
       termsAndPrivacyAccepted,
       address: newAddress,
+      sendNotificatoins: allowSendNotifications ? new Date() : null,
     };
     handleFormSubmit(newPersonalInfo);
   };
@@ -513,6 +521,14 @@ const PersonalDataForm: React.FC<PersonalDataFormProps> = ({
             onChange={({ target }) => setAcceptToUsePhoto(target.checked)}
           >
             {t('user_data_form.accept_to_use_profile_pic')}
+          </Checkbox>
+        </Form.Item>
+        <Form.Item style={{ textAlign: 'center' }} name="useSendNotifications">
+          <Checkbox
+            checked={allowSendNotifications}
+            onChange={({ target }) => setAllowSendNotifications(target.checked)}
+          >
+            {t('user_data_form.allow_send_notifications')}
           </Checkbox>
         </Form.Item>
         <Form.Item

--- a/web-client/src/modules/personalData/containers/PersonalDataFormContainer/PersonalDataFormContainer.tsx
+++ b/web-client/src/modules/personalData/containers/PersonalDataFormContainer/PersonalDataFormContainer.tsx
@@ -142,6 +142,7 @@ const PersonalDataFormContainer: React.FC = (): React.ReactElement => {
       termsAndPrivacyAccepted,
       displayName,
       displayPic,
+      sendNotificatoins,
     } = personalInfo;
     // eslint-disable-next-line max-len
     const address = `${newAddress.address1},${newAddress.address2},${newAddress.city},${newAddress.state},${newAddress.postalCode},${newAddress.country}`;
@@ -159,6 +160,7 @@ const PersonalDataFormContainer: React.FC = (): React.ReactElement => {
                 termsAndPrivacyAccepted,
                 displayName,
                 user.uid,
+                sendNotificatoins,
                 displayPic,
               ),
             );

--- a/web-client/src/pages/MasterPage.tsx
+++ b/web-client/src/pages/MasterPage.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react-router-dom';
 import DashboardLayout from 'src/components/DashboardLayout/DashboardLayout';
 import { signOutCurrentUserAction } from 'src/ducks/auth/actions';
-import { updateUserPrivilegedInformation } from 'src/ducks/profile/actions';
 import { ProfileState } from 'src/ducks/profile/types';
 import { changeModal, setRequest } from 'src/ducks/requests/actions';
 import { RequestState } from 'src/ducks/requests/types';
@@ -31,11 +30,7 @@ const MasterPage = (): ReactElement => {
 
   const dispatch = useDispatch();
 
-  const newRequestSubmitHandler = (
-    title: string,
-    body: string,
-    sendNotifications: boolean,
-  ) => {
+  const newRequestSubmitHandler = (title: string, body: string) => {
     if (
       profileState.profile &&
       profileState.userRef &&
@@ -49,17 +44,6 @@ const MasterPage = (): ReactElement => {
           pinUserSnapshot: profileState.profile.toObject() as IUser,
           latLng: profileState.privilegedInformation.address.coords,
         }),
-      );
-    }
-
-    if (profileState.uid && profileState.privilegedInformation) {
-      profileState.privilegedInformation.sendNotifications =
-        sendNotifications === true;
-      dispatch(
-        updateUserPrivilegedInformation(
-          profileState.uid,
-          profileState.privilegedInformation,
-        ),
       );
     }
   };

--- a/web-client/src/translations/en.json
+++ b/web-client/src/translations/en.json
@@ -52,7 +52,8 @@
       "terms_conditions_error": "You need to accept the Terms & Conditions.",
       "full_name_error_message": "You need to fill your name.",
       "display_name_error_message": "You need to fill your display name.",
-      "address_error_message": "You need to fill your address."
+      "address_error_message": "You need to fill your address.",
+      "allow_send_notifications": "Would you like us to send you notifications and emails?"
     },
     "newRequest": {
       "title": "New Request",


### PR DESCRIPTION
## Description
Moves the option for opting-in for notifications and emails into the personal data page and removed from the new requests modal.
Also updates the `privilegedInformation` model in the `functions` project to make this field an optional field.
Also syncs the `web-client` version of the model with that of the `functions` 
## Motivation

## Testing Guidelines

## Release Checklist

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
