### PR TITLE
feat(menudrawer): add ability to switch application preference

### DIFF
--- a/web-client/src/components/DashboardLayout/DashboardLayout.tsx
+++ b/web-client/src/components/DashboardLayout/DashboardLayout.tsx
@@ -14,6 +14,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
   children,
   isCav,
   logoutHandler,
+  toggleApplicationPreference,
 }) => {
   const [menuVisible, setMenuVisible] = useState(false);
   const [notificationVisible, setNotificationVisible] = useState(false);
@@ -28,6 +29,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
         profileData={profileData}
         logoutHandler={logoutHandler}
         isCav={isCav}
+        toggleApplicationPreference={toggleApplicationPreference}
       />
       <NotificationsDrawer
         visible={notificationVisible}
@@ -53,6 +55,7 @@ interface DashboardLayoutProps {
   children?: React.ReactNode;
   isCav?: boolean;
   logoutHandler: Function;
+  toggleApplicationPreference: Function;
 }
 
 export default DashboardLayout;

--- a/web-client/src/components/MenuDrawer/MenuDrawer.tsx
+++ b/web-client/src/components/MenuDrawer/MenuDrawer.tsx
@@ -1,6 +1,11 @@
-import { LogoutOutlined, MailOutlined } from '@ant-design/icons';
+import {
+  LogoutOutlined,
+  MailOutlined,
+  UserSwitchOutlined,
+} from '@ant-design/icons';
 import { Drawer } from 'antd';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { User } from 'src/models/users';
 import styled from 'styled-components';
@@ -15,37 +20,48 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({
   profileData,
   logoutHandler,
   isCav,
-}) => (
-  <SideDrawer
-    placement="left"
-    closable
-    onClose={closeDrawer}
-    visible={visible}
-    width="100%"
-  >
-    <SideDrawerProfile profileData={profileData} isCav={isCav} />
-    <SideDrawerMenu
-      items={menuItems || []}
-      closeDrawer={closeDrawer}
-      isCav={isCav}
-    />
-    <BottomLinks>
-      <Link to={{ pathname: '/' }} onClick={closeDrawer}>
-        <MailOutlined />
-        Contact us
-      </Link>
-      <div
-        onClick={() => {
-          closeDrawer();
-          logoutHandler();
-        }}
-      >
-        <LogoutOutlined />
-        Sign out
-      </div>
-    </BottomLinks>
-  </SideDrawer>
-);
+  toggleApplicationPreference,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <SideDrawer
+      placement="left"
+      closable
+      onClose={closeDrawer}
+      visible={visible}
+      width="100%"
+    >
+      <SideDrawerProfile profileData={profileData} isCav={isCav} />
+      <SideDrawerMenu
+        items={menuItems || []}
+        closeDrawer={closeDrawer}
+        isCav={isCav}
+      />
+      <BottomLinks>
+        <Link to={{ pathname: '/' }} onClick={closeDrawer}>
+          <MailOutlined />
+          {t('menuDrawer.contactUs')}
+        </Link>
+        <div onClick={() => toggleApplicationPreference()}>
+          <UserSwitchOutlined />
+          {`${
+            isCav ? t('menuDrawer.switchToPIN') : t('menuDrawer.switchToCAV')
+          }`}
+        </div>
+        <div
+          onClick={() => {
+            closeDrawer();
+            logoutHandler();
+          }}
+        >
+          <LogoutOutlined />
+          {t('menuDrawer.logout')}
+        </div>
+      </BottomLinks>
+    </SideDrawer>
+  );
+};
 
 const SideDrawer = styled(Drawer)`
   .ant-drawer-body {
@@ -81,6 +97,7 @@ interface MenuDrawerProps {
   profileData?: User;
   logoutHandler: Function;
   isCav?: boolean;
+  toggleApplicationPreference: Function;
 }
 
 export default MenuDrawer;

--- a/web-client/src/pages/MasterPage.tsx
+++ b/web-client/src/pages/MasterPage.tsx
@@ -11,6 +11,9 @@ import { signOutCurrentUserAction } from 'src/ducks/auth/actions';
 import { ProfileState } from 'src/ducks/profile/types';
 import { RoleInfoLocation } from 'src/modules/personalData/pages/routes/RoleInfoRoute/constants';
 
+import { AuthState } from '../ducks/auth/types';
+import { updateUserProfile } from '../ducks/profile/actions';
+import { ApplicationPreference } from '../models/users';
 import modules from '../modules';
 import NotFoundRoute from './routes/NotFoundRoute';
 import ProtectedRoute from './routes/ProtectedRoute';
@@ -23,6 +26,20 @@ const MasterPage = (): ReactElement => {
 
   const dispatch = useDispatch();
 
+  const authState = useSelector(({ auth }: { auth: AuthState }) => auth);
+
+  const toggleApplicationPreference = () => {
+    const user = profileState.profile;
+    if (user && authState.user) {
+      const currentPreference = user.applicationPreference;
+      user.applicationPreference =
+        currentPreference === ApplicationPreference.cav
+          ? ApplicationPreference.pin
+          : ApplicationPreference.cav;
+      dispatch(updateUserProfile(authState.user.uid, user));
+    }
+  };
+
   const renderLayout = routeModule => {
     if (routeModule.layout === 'dashboard' && userProfile) {
       return (
@@ -31,6 +48,7 @@ const MasterPage = (): ReactElement => {
           profileData={userProfile}
           isCav={userProfile?.applicationPreference === 'cav'}
           logoutHandler={() => dispatch(signOutCurrentUserAction())}
+          toggleApplicationPreference={toggleApplicationPreference}
         >
           <Route path={routeModule.path} component={routeModule.component} />
         </DashboardLayout>

--- a/web-client/src/translations/en.json
+++ b/web-client/src/translations/en.json
@@ -19,6 +19,12 @@
       "info": "We are only allowing Facebook Users with a verified account 6 months or older for safety. \nWe are working hard to bring more ways to login in the future. \nThank you for your patience.",
       "facebookButtonLabel": "Continue with Facebook"
     },
+    "menuDrawer": {
+      "contactUs": "Contact us",
+      "logout": "Sign out",
+      "switchToCAV": "Switch to Volunteer",
+      "switchToPIN": "Switch to Person In Need"
+    },
     "phoneNumber": {
       "sub_title": "Enter your telephone number to begin",
       "info": "This information is fundamental to validate your account. Data and rates may apply.",


### PR DESCRIPTION
## Description
Added the ability for user to switch between CAV/PIN 

## Motivation
Allows user to switch preference

## Testing Guidelines
In the side menu, click on the Switch to CAV/PIN link and make sure that the user profile is updated correctly

## Release Checklist

- [ ] This code has unit tests
- [x] I have a plan to verify that these changes are working as expected after deploy
- [x] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
![Screen Shot 2020-05-28 at 2 19 43 PM](https://user-images.githubusercontent.com/5454024/83178338-64154e80-a0ee-11ea-947c-11233f9a42cb.png)
![Screen Shot 2020-05-28 at 2 19 28 PM](https://user-images.githubusercontent.com/5454024/83178339-64ade500-a0ee-11ea-945f-89c4f1587b28.png)
