### PR TITLE
distributing controls between right and left

### DIFF
--- a/web-client/src/components/WebClientMap/WebClientMap.tsx
+++ b/web-client/src/components/WebClientMap/WebClientMap.tsx
@@ -9,11 +9,11 @@ import WebClientMapMessage from './WebClientMapMessage';
 
 const createMapOptions = maps => ({
   zoomControlOptions: {
-    position: maps.ControlPosition.RIGHT_CENTER,
+    position: maps.ControlPosition.TOP_RIGHT,
     style: maps.ZoomControlStyle.SMALL,
   },
   mapTypeControlOptions: {
-    position: maps.ControlPosition.TOP_RIGHT,
+    position: maps.ControlPosition.TOP_LEFT,
   },
   mapTypeControl: true,
 });


### PR DESCRIPTION
Controls were all on the right.
Now are on Top Left and Top Right.
I hope that putting things on TOP will make them more accessible to small screens

The zoom control was hidden in this example using debugger tools.  Not sure if this is how an actual device would behave.  This change does not remedy the issue -- the zoom control is still hidden.  But the display is less crowded on other size displays.

![mapcontrolsHidden](https://user-images.githubusercontent.com/1453956/83700627-528fe300-a5d5-11ea-98b1-3bb68462e6ec.png)
