### PR TITLE
fix(dropdown): fix issue when clicking header links

### DIFF
--- a/site/src/components/header/index.js
+++ b/site/src/components/header/index.js
@@ -53,7 +53,7 @@ function Header({ navSections }) {
               <li key={section.id}>
                 <Link
                   to={section.link}
-                  onClick={drawerToggler}
+                  onClick={() => setDrawerClose(true)}
                   activeClassName="active"
                 >
                   <p>{section.title}</p>


### PR DESCRIPTION
## Description
When clicking on the links this happens:
![image](https://user-images.githubusercontent.com/35262512/84553370-039c2900-ad0c-11ea-8eec-f2845900f977.png)

I changed it to stop doing that

## Release Checklist

- [ ] This code has unit tests
- [x] I have a plan to verify that these changes are working as expected after deploy
- [x] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
