### PR TITLE
Styled Components renamed.  Css placed within them

### DIFF
--- a/web-client/src/components/BottomNavbar/BottomNavbar.tsx
+++ b/web-client/src/components/BottomNavbar/BottomNavbar.tsx
@@ -12,14 +12,14 @@ import styled from 'styled-components';
 
 import { NewRequestsLocation } from '../../modules/requests/pages/routes/NewRequestsRoute/constants';
 
-const BottomNavbar: React.FC<BottomNavProps> = ({
+const BottomNavbar: React.FC<BottomNavbarProps> = ({
   openMenu,
   openNotifications,
   isCav,
 }) => {
   const history = useHistory();
   return (
-    <Wrapper>
+    <BottomNavbarContainer>
       <NavButton isCav={isCav} onClick={openMenu}>
         <SideMenuIcon />
       </NavButton>
@@ -41,7 +41,7 @@ const BottomNavbar: React.FC<BottomNavProps> = ({
       <NavButton isCav={isCav} onClick={openNotifications}>
         <NotificationsIcon />
       </NavButton>
-    </Wrapper>
+    </BottomNavbarContainer>
   );
 };
 
@@ -63,7 +63,7 @@ const NavButton = styled('button')<{ isCav?: boolean }>`
   }
 `;
 
-const Wrapper = styled.div`
+const BottomNavbarContainer = styled.div`
   display: flex;
   justify-content: space-evenly;
   align-items: center;
@@ -75,7 +75,7 @@ const Wrapper = styled.div`
   z-index: 999;
 `;
 
-interface BottomNavProps {
+interface BottomNavbarProps {
   openMenu: () => void;
   openNotifications: () => void;
   isCav?: boolean;

--- a/web-client/src/components/Buttons/index.tsx
+++ b/web-client/src/components/Buttons/index.tsx
@@ -32,7 +32,8 @@ export const StepForwardButton = styled(Button)`
   &:active,
   &:focus-within {
     background-color: ${COLORS.stepForwardEnhanced};
-    /* overrides antd */
+
+    /* overrides antd purple color */
     color: white;
   }
 `;

--- a/web-client/src/components/DashboardLayout/DashboardLayout.tsx
+++ b/web-client/src/components/DashboardLayout/DashboardLayout.tsx
@@ -23,7 +23,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
   const [notificationVisible, setNotificationVisible] = useState(false);
 
   return (
-    <StyledLayout>
+    <DashboardLayoutContainer>
       <TopNavbar />
       <MenuDrawer
         visible={menuVisible}
@@ -40,17 +40,17 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
         closeDrawer={() => setNotificationVisible(false)}
         isCav={isCav}
       />
-      <StyledLayoutContent>{children}</StyledLayoutContent>
+      <DashboardContent>{children}</DashboardContent>
       <BottomNavbar
         openMenu={() => setMenuVisible(true)}
         openNotifications={() => setNotificationVisible(true)}
         isCav={isCav}
       />
-    </StyledLayout>
+    </DashboardLayoutContainer>
   );
 };
 
-const StyledLayout = styled(Layout)`
+const DashboardLayoutContainer = styled(Layout)`
   position: absolute;
   top: 0;
   bottom: 0;
@@ -59,7 +59,7 @@ const StyledLayout = styled(Layout)`
   overflow: auto;
 `;
 
-const StyledLayoutContent = styled(Layout.Content)`
+const DashboardContent = styled(Layout.Content)`
   margin: 64px 0;
   overflow-x: hidden;
   overflow-y: scroll;

--- a/web-client/src/components/IntroLogo/IntroLogo.tsx
+++ b/web-client/src/components/IntroLogo/IntroLogo.tsx
@@ -5,12 +5,13 @@ const Logo = styled.img`
   height: 125px;
   width: 125px;
 `;
-interface WrapperProps {
+
+interface IntroLogoProps {
   src: string;
   alt: string;
 }
 
-const IntroLogo: React.FC<WrapperProps> = ({
+const IntroLogo: React.FC<IntroLogoProps> = ({
   src,
   alt,
 }): React.ReactElement => <Logo src={src} alt={alt} />;

--- a/web-client/src/components/IntroWrapper/IntroWrapper.tsx
+++ b/web-client/src/components/IntroWrapper/IntroWrapper.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const StyledIntro = styled.div`
+const IntroContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 50px 50px;
 `;
 
-const IntroWrapper: React.FC<WrapperProps> = ({
+const IntroWrapper: React.FC<IntroWrapperProps> = ({
   children,
-}): React.ReactElement => <StyledIntro>{children}</StyledIntro>;
+}): React.ReactElement => <IntroContainer>{children}</IntroContainer>;
 
-interface WrapperProps {
+interface IntroWrapperProps {
   children: React.ReactNode;
 }
 

--- a/web-client/src/components/LoadingWrapper/LoadingWrapper.tsx
+++ b/web-client/src/components/LoadingWrapper/LoadingWrapper.tsx
@@ -3,26 +3,26 @@ import { useTranslation } from 'react-i18next';
 import LoadingLogo from 'src/assets/loadinglogo.svg';
 import styled from 'styled-components';
 
-const Container = styled.div`
+const LoadingWrapperContainer = styled.div`
   display: flex;
   height: 100vh;
   justify-content: center;
   align-items: center;
 `;
 
-const LoadingWrapper: React.FC<WrapperProps> = ({
+const LoadingWrapper: React.FC<LoadingWrapperProps> = ({
   children,
 }): React.ReactElement => {
   const { t } = useTranslation();
   return (
-    <Container>
+    <LoadingWrapperContainer>
       <img src={LoadingLogo} alt={t('components.loading_a11y_message')} />
       {children}
-    </Container>
+    </LoadingWrapperContainer>
   );
 };
 
-interface WrapperProps {
+interface LoadingWrapperProps {
   children?: React.ReactNode;
 }
 

--- a/web-client/src/components/NotificationsDrawer/Notification.tsx
+++ b/web-client/src/components/NotificationsDrawer/Notification.tsx
@@ -8,10 +8,10 @@ import { TimelineViewLocation } from 'src/modules/timeline/pages/routes/Timeline
 import { COLORS } from 'src/theme/colors';
 import styled from 'styled-components';
 
-const Text = styled.p`
+const RequestNotification = styled.p`
   margin-bottom: 0px;
 `;
-const ReqTitle = styled.span`
+const RequestTitle = styled.span`
   color: ${COLORS.brandOrange};
 `;
 
@@ -40,118 +40,118 @@ const Notification: React.FC<NotificationProps> = ({
     if (offerStatus === OfferStatus.accepted) {
       if (isCav) {
         return (
-          <Text>
+          <RequestNotification>
             {offerRequest?.pinUserSnapshot.displayName ||
               offerRequest?.pinUserSnapshot.username ||
               t('components.notification.request_author')}
             {t('components.notification.volunteer_accepted')}
             {offerRequest?.title ? (
-              <ReqTitle>{offerRequest.title}</ReqTitle>
+              <RequestTitle>{offerRequest.title}</RequestTitle>
             ) : (
               'a request'
             )}
             .
-          </Text>
+          </RequestNotification>
         );
       }
       return (
-        <Text>
+        <RequestNotification>
           {t('components.notification.pin_accepted')}
           {cavUser.displayName || cavUser.username}
           {t('for')}
           {offerRequest?.title ? (
-            <ReqTitle>{offerRequest.title}</ReqTitle>
+            <RequestTitle>{offerRequest.title}</RequestTitle>
           ) : (
             t('components.notification.your_task')
           )}
           .
-        </Text>
+        </RequestNotification>
       );
     }
     if (offerStatus === OfferStatus.rejected) {
       if (isCav) {
         return (
-          <Text>
+          <RequestNotification>
             {offerRequest?.pinUserSnapshot.displayName ||
               offerRequest?.pinUserSnapshot.username ||
               `${t('components.notification.request_author')} ${t(
                 'components.notification.already_helped',
               )}`}
             {offerRequest?.title ? (
-              <ReqTitle>{offerRequest.title}</ReqTitle>
+              <RequestTitle>{offerRequest.title}</RequestTitle>
             ) : (
               t('components.notification.a_request')
             )}
             .
-          </Text>
+          </RequestNotification>
         );
       }
       return (
-        <Text>
+        <RequestNotification>
           {t('components.notification.pin_rejected')}
           {cavUser.displayName || cavUser.username}
           {t('for')}
           {offerRequest?.title ? (
-            <ReqTitle>{offerRequest.title}</ReqTitle>
+            <RequestTitle>{offerRequest.title}</RequestTitle>
           ) : (
             t('components.notification.your_task')
           )}
           .
-        </Text>
+        </RequestNotification>
       );
     }
     if (offerStatus === OfferStatus.pending) {
       if (isCav) {
         return (
-          <Text>
+          <RequestNotification>
             {t('components.notification.cav_offer')}
             {offerRequest?.title ? (
-              <ReqTitle>{offerRequest.title}</ReqTitle>
+              <RequestTitle>{offerRequest.title}</RequestTitle>
             ) : (
               t('components.notification.a_request')
             )}
             .
-          </Text>
+          </RequestNotification>
         );
       }
       return (
-        <Text>
+        <RequestNotification>
           {cavUser.displayName || cavUser.username}
           {t('components.notification.offered_help')}
           {offerRequest?.title ? (
-            <ReqTitle>{offerRequest.title}</ReqTitle>
+            <RequestTitle>{offerRequest.title}</RequestTitle>
           ) : (
             t('components.notification.your_task')
           )}
           .
-        </Text>
+        </RequestNotification>
       );
     }
     if (offerStatus === OfferStatus.cavDeclined) {
       if (isCav) {
         return (
-          <Text>
+          <RequestNotification>
             {t('components.notification.pin_declined_help')}
             {offerRequest?.title ? (
-              <ReqTitle>{offerRequest.title}</ReqTitle>
+              <RequestTitle>{offerRequest.title}</RequestTitle>
             ) : (
               t('components.notification.a_request')
             )}
             .
-          </Text>
+          </RequestNotification>
         );
       }
       return (
-        <Text>
+        <RequestNotification>
           {cavUser.displayName || cavUser.username}
           {t('components.notification.cav_declined_help')}
           {offerRequest?.title ? (
-            <ReqTitle>{offerRequest.title}</ReqTitle>
+            <RequestTitle>{offerRequest.title}</RequestTitle>
           ) : (
             t('components.notification.your_task')
           )}
           .
-        </Text>
+        </RequestNotification>
       );
     }
   };

--- a/web-client/src/components/NotificationsDrawer/NotificationsHeader.tsx
+++ b/web-client/src/components/NotificationsDrawer/NotificationsHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
 import { COLORS } from '../../theme/colors';
 
@@ -14,38 +15,36 @@ const NotificationsHeader: React.FC<NotificationsHeaderProps> = ({
 }): React.ReactElement => {
   const { t } = useTranslation();
 
+  const NotificationHeaderContainer = styled.div`
+    margin: 25px;
+    margin-bottom: 15px;
+    display: flex;
+    justify-content: space-between;
+    font-family: Roboto, sans-serif;
+  `;
+
+  const Header2 = styled.h2`
+    background-color: ${isCav ? COLORS.primaryDark : COLORS.brandOrange};
+    color: #ffffff;
+    padding-left: 10px;
+    padding-right: 10px;
+    margin-top: 10px;
+    margin-bottom: 17px;
+    border-radius: 5px;
+  `;
+
+  const Header1 = styled.h1`
+    color: rgba(0, 0, 0, 0.65);
+    font-size: 30px;
+  `;
+
   return (
-    <div
-      style={{
-        margin: '25px',
-        marginBottom: '15px',
-        display: 'flex',
-        justifyContent: 'space-between',
-        fontFamily: 'Roboto, sans-serif',
-      }}
-    >
-      <h1
-        style={{
-          color: 'rgba(0, 0, 0, 0.65)',
-          fontSize: '30px',
-        }}
-      >
+    <NotificationHeaderContainer>
+      <Header1>
         <b> {t('components.notification.notifications')} </b>
-      </h1>
-      <h2
-        style={{
-          backgroundColor: isCav ? COLORS.primaryDark : COLORS.brandOrange,
-          color: '#FFFFFF',
-          paddingLeft: '10px',
-          paddingRight: '10px',
-          marginTop: '10px',
-          marginBottom: '17px',
-          borderRadius: '5px',
-        }}
-      >
-        {numNotifications}
-      </h2>
-    </div>
+      </Header1>
+      <Header2>{numNotifications}</Header2>
+    </NotificationHeaderContainer>
   );
 };
 export default NotificationsHeader;

--- a/web-client/src/components/NotificationsDrawer/NotificationsList.tsx
+++ b/web-client/src/components/NotificationsDrawer/NotificationsList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Offer } from 'src/models/offers';
+import styled from 'styled-components';
 
 import Notification from './Notification';
 
@@ -9,6 +10,13 @@ interface NotificationsList {
   unseenOffers: Offer[];
 }
 
+const NotificationListContainer = styled.div`
+  margin-left: 15px,
+  margin-right: 15px,
+  color: rgba(0, 0, 0, 0.65),
+  font-family: Roboto, sans-serif,
+`;
+
 const NotificationsList: React.FC<NotificationsList> = ({
   isCav,
   unseenOffers,
@@ -16,14 +24,7 @@ const NotificationsList: React.FC<NotificationsList> = ({
   const { t } = useTranslation();
 
   return (
-    <div
-      style={{
-        marginLeft: '15px',
-        marginRight: '15px',
-        color: 'rgba(0, 0, 0, 0.65)',
-        fontFamily: 'Roboto, sans-serif',
-      }}
-    >
+    <NotificationListContainer>
       {unseenOffers.length > 0 &&
         unseenOffers.map((item, index) => (
           <Notification
@@ -41,7 +42,7 @@ const NotificationsList: React.FC<NotificationsList> = ({
           <p>{t('components.notification.no_notifications')}</p>
         </div>
       )}
-    </div>
+    </NotificationListContainer>
   );
 };
 export default NotificationsList;

--- a/web-client/src/components/SideDrawerMenu/SideDrawerMenu.tsx
+++ b/web-client/src/components/SideDrawerMenu/SideDrawerMenu.tsx
@@ -70,7 +70,7 @@ const SideDrawerMenu: React.FC<SideDrawerMenuProps> = ({
     defaultSelectedKeys.push(`${Number(items[0].id) - 1}`);
   }
   return (
-    <Wrapper isCav={isCav}>
+    <SideDrawerMenuContainer isCav={isCav}>
       <Menu
         defaultOpenKeys={defaultOpenKeys}
         defaultSelectedKeys={defaultSelectedKeys}
@@ -84,11 +84,11 @@ const SideDrawerMenu: React.FC<SideDrawerMenuProps> = ({
           />
         ))}
       </Menu>
-    </Wrapper>
+    </SideDrawerMenuContainer>
   );
 };
 
-const Wrapper = styled('div')<{ isCav?: boolean }>`
+const SideDrawerMenuContainer = styled('div')<{ isCav?: boolean }>`
   flex: auto;
 
   .ant-menu {


### PR DESCRIPTION
Code Conventions

All Component Names follow standard OO Naming conventions
* Inheritance Relationships can be indicated by appending the name of the subclass
* All styled-components must have meaningful names that indicate their usage within the markup.  
* They must be treated exactly the same as React Components
* The root styled-component for the module is {ModuleName}Container
* https://blog.elpassion.com/naming-101-quick-guide-on-how-to-name-things-a9bcbfd02f02

All css must occur in styled-components

Styled-components must be defined
* Use Props: defined at the bottom of the React component, after the return statement but before the terminal curly brace
* Do not use Props:  After the curly brace

----------------------------------------------
const BlogPost = ({props}) => (
  <  BlogPostContainer>
    <  Title >{props.title}</ Title >
    <  Descripton  >{props.description}< /   Descripton>
  < /  BlogPostContainer >
)

const BlogPostContainer = styled.div ``
const Title = styled.div ``
const Description = styled.div ``

const BlogPostProps = {
  name: string, 
  description: string
}
