### PR TITLE
base text styles from figma

### DIFF
--- a/web-client/src/components/figma/BlockStyles.ts
+++ b/web-client/src/components/figma/BlockStyles.ts
@@ -1,0 +1,9 @@
+/* Common layout patterns used by Figma */
+
+import styled from 'styled-components';
+
+const ExampleDivStyle = styled.div`
+  margin: 15px;
+`;
+
+export { ExampleDivStyle };

--- a/web-client/src/components/figma/TextStyles.ts
+++ b/web-client/src/components/figma/TextStyles.ts
@@ -1,0 +1,129 @@
+/* Common font styles used by Figma */
+
+import styled from 'styled-components';
+
+const H1Font = styled.span`
+  /* H1 */
+
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 44px;
+  line-height: 76px;
+  /* identical to box height, or 173% */
+
+  color: #c4c4c4;
+`;
+
+const H2Font = styled.span`
+  /* h2 */
+
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 38px;
+  line-height: 46px;
+  /* identical to box height, or 121% */
+
+  color: #c4c4c4;
+`;
+
+const H3Font = styled.span`
+  /* h3 */
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 30px;
+  line-height: 36px;
+  /* identical to box height, or 120% */
+  color: #c4c4c4;
+`;
+
+const H4Font = styled.span`
+  /* h4 */
+
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 24px;
+  line-height: 32px;
+  /* identical to box height, or 133% */
+
+  color: #c4c4c4;
+`;
+
+const H5Font = styled.span`
+  /* h5 */
+
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 20px;
+  line-height: 28px;
+  /* identical to box height, or 140% */
+
+  color: #c4c4c4;
+`;
+
+const H6Font = styled.span`
+  /* h6 */
+
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 18px;
+  line-height: 26px;
+  /* identical to box height, or 144% */
+
+  color: #c4c4c4;
+`;
+
+const FontSizeLg = styled.span`
+  /* font-size-lg */
+
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 16px;
+  line-height: 24px;
+  /* identical to box height, or 150% */
+
+  color: #c4c4c4;
+`;
+
+const FontSizeBase = styled.div`
+  /* font-size-base */
+
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 14px;
+  line-height: 22px;
+  /* identical to box height, or 157% */
+
+  color: #c4c4c4;
+`;
+
+const FontSizeSm = styled.span`
+  /* font-size-sm */
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 12px;
+  line-height: 20px;
+  /* identical to box height, or 167% */
+
+  color: #c4c4c4;
+`;
+
+export {
+  H1Font,
+  H2Font,
+  H3Font,
+  H4Font,
+  H5Font,
+  H6Font,
+  FontSizeLg,
+  FontSizeSm,
+  FontSizeBase,
+};

--- a/web-client/src/components/figma/index.ts
+++ b/web-client/src/components/figma/index.ts
@@ -1,2 +1,25 @@
-const foo = 'FOO';
-export default foo;
+import { ExampleDivStyle } from './BlockStyles';
+import {
+  FontSizeBase,
+  FontSizeLg,
+  FontSizeSm,
+  H1Font,
+  H2Font,
+  H3Font,
+  H4Font,
+  H5Font,
+  H6Font,
+} from './TextStyles';
+
+export {
+  H1Font,
+  H2Font,
+  H3Font,
+  H4Font,
+  H5Font,
+  H6Font,
+  FontSizeLg,
+  FontSizeSm,
+  FontSizeBase,
+  ExampleDivStyle,
+};


### PR DESCRIPTION
@sabind @ashwinkjoseph 
This work is preliminary.
Do you think this is a good way to proceed?

I don't know whether predefined BlockStyles will be that useful.
Also, Headers are block-level rather than inline styles, so I am using "H1Text" instead of "H1" as names.

The idea is to start making people do:

< BlockStyle >
   < TextStyle >
     content
  < / TextStyle >
< / BlockStyle >
 

