### PR TITLE
fix: make 'please enter your type' textbox mandatory #852

### DIFF
--- a/web-client/src/modules/requests/components/NewRequest/NewRequest.tsx
+++ b/web-client/src/modules/requests/components/NewRequest/NewRequest.tsx
@@ -50,7 +50,7 @@ const NewRequest: React.FC<NewRequestProps> = ({
         name="other"
         rules={[
           {
-            required: form.getFieldValue('type') === 'Other',
+            required: true,
             message: t('newRequest.form.other_error_message'),
           },
         ]}


### PR DESCRIPTION
## Description

The field should always be `required:true` because `mayBeOtherField()` only renders the field when it is needed.

## Additional Notes

solves #852 
