### PR TITLE
fix: adjusted cannot help button

### DIFF
--- a/web-client/src/components/Buttons/index.tsx
+++ b/web-client/src/components/Buttons/index.tsx
@@ -39,7 +39,7 @@ export const MailAuthButton = styled(Button)`
 export const StepBackButton = styled(Button)`
   border-radius: 4px;
   white-space: nowrap;
-  width: 100%;
+  max-width: 110px;
   background-color: ${COLORS.stepBackwardNormal};
   color: white;
   font-weight: 700;
@@ -57,7 +57,7 @@ export const StepForwardButton = styled(Button)`
   border-radius: 4px;
   white-space: nowrap;
   min-width: 100%;
-  max-width: 175px;
+  max-width: 180px;
   background-color: ${COLORS.stepForwardNormal};
   color: white;
   font-weight: 700;

--- a/web-client/src/modules/requests/components/RequestItem/RequestItem.tsx
+++ b/web-client/src/modules/requests/components/RequestItem/RequestItem.tsx
@@ -129,8 +129,8 @@ const RequestItem: React.FC<RequestItemProps> = ({
           >
             {request.description}
           </Paragraph>
-          <Row justify="space-around">
-            <Col span={11}>
+          <Row justify="space-between" gutter={16}>
+            <Col>
               <StepBackButton
                 loading={loading && actionPerformed === 2}
                 disabled={loading && actionPerformed !== 2}
@@ -142,7 +142,7 @@ const RequestItem: React.FC<RequestItemProps> = ({
                 {t('modules.requests.cannot_help')}
               </StepBackButton>
             </Col>
-            <Col span={11}>
+            <Col>
               <StepForwardButton
                 loading={loading && actionPerformed === 1}
                 disabled={loading && actionPerformed !== 1}


### PR DESCRIPTION
## Description

Made styling adjustments to the "Cannot Help" button so the text doesn't go out of the button's boundaries.

## Motivation

To polish the aesthetic of the request item. To improve user's readability.

## Testing Guidelines

## Release Checklist

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
