### PR TITLE
pr for bug: fix bug 1010, address ref and end case incorrect

### DIFF
--- a/web-client/src/components/WebClientMap/utils.tsx
+++ b/web-client/src/components/WebClientMap/utils.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { ProfileState } from 'src/ducks/profile/types';
 
 // default center
-const ANGKOR_WAT = {
+const DEFAULT_COORDS = {
   lat: 13.4124693,
   lng: 103.8667,
 };
@@ -17,21 +17,14 @@ export const metersToImperial = (meters: number) =>
   `${(meters * 0.000621371).toFixed(1)}mi`;
 
 export const getCoordsFromProfile = (profileState: ProfileState) => {
-  if (profileState?.privilegedInformation?.addresses) {
-    const addressToUse = profileState.privilegedInformation.addresses.default
-      ? profileState.privilegedInformation.addresses.default
-      : profileState.privilegedInformation.addresses[
-          Object.keys(profileState.privilegedInformation.addresses)[0]
-        ];
-    return {
-      lat: addressToUse.coords.latitude,
-      lng: addressToUse.coords.longitude,
-    };
+  const addresses = profileState?.privilegedInformation?.addresses;
+  let addressToUse;
+  if (addresses) {
+    addressToUse = addresses.default ? addresses.default : addresses[0];
   }
-  return {
-    lat: ANGKOR_WAT.lat,
-    lng: ANGKOR_WAT.lng,
-  };
+  return addressToUse
+    ? { lat: addressToUse.coords.latitude, lng: addressToUse.coords.longitude }
+    : DEFAULT_COORDS;
 };
 
 export const getStreetAddressFromProfile = (profileState: ProfileState) => {


### PR DESCRIPTION
Closes bug #1010 

## Description
See bug #1010

## Testing Guidelines
Try reviewing map (Find option or list/find url path) when:
- you have not logged in
- you have logged into an account with no addresses created
- you have logged into an account with one or two addresses, neither of them marked as default (currently, you mark an address as a default by putting the label "default")
- you have logged nto an account with two addresses, the second one created should be marked as "default"
