### PR TITLE
Bug 1021 tab logic

### DIFF
--- a/web-client/src/ducks/requests/actions.ts
+++ b/web-client/src/ducks/requests/actions.ts
@@ -3,56 +3,54 @@ import { IRequest, Request } from 'src/models/requests';
 /* TODO: why rename? */
 import {
   createUserRequest,
-  getAcceptedRequest as getAcceptedRequestFunc,
+  getAcceptedPost as getAcceptedPostFunc,
   getArchivedRequest as getArchivedRequestFunc,
   getFinishedRequest as getFinishedRequestFunc,
-  getOngoingRequest as getOngoingRequestFunc,
-  getOpenRequest as getOpenRequestFunc,
-  observeOpenRequests as observeOpenRequestsFunc,
+  getOngoingPost as getOngoingPostFunc,
+  getOpenPost as getOpenPostFunc,
+  observeOpenPosts as observeOpenPostsFunc,
   setUserRequest,
 } from './functions';
 import {
   CHANGE_MODAL,
-  GET_ACCEPTED,
   GET_ARCHIVED,
   GET_FINISHED,
+  GET_OFFER_POST,
   GET_ONGOING,
-  GET_OPEN,
-  IgetOpenRequests,
-  OBSERVE_OPEN_REQUESTS,
+  GET_REQUEST_POST,
+  IgetOpenPosts,
+  OBSERVE_OPEN_POSTS,
   RESET_SET,
   SET,
   SET_TEMP_REQUEST,
 } from './types';
 
-export const getOpenRequests = (payload: IgetOpenRequests) => (
-  dispatch: Function,
-) =>
+export const getOpenPosts = (payload: IgetOpenPosts) => (dispatch: Function) =>
   dispatch({
-    type: GET_OPEN,
-    firebase: getOpenRequestFunc,
+    type: GET_REQUEST_POST,
+    firebase: getOpenPostFunc,
     payload,
   });
 
-export const getAcceptedRequests = (payload: IgetOpenRequests) => (
+export const getAcceptedPosts = (payload: IgetOpenPosts) => (
   dispatch: Function,
 ) =>
   dispatch({
-    type: GET_ACCEPTED,
-    firebase: getAcceptedRequestFunc,
+    type: GET_OFFER_POST,
+    firebase: getAcceptedPostFunc,
     payload,
   });
 
-export const getOngoingRequests = (payload: IgetOpenRequests) => (
+export const getOngoingPosts = (payload: IgetOpenPosts) => (
   dispatch: Function,
 ) =>
   dispatch({
     type: GET_ONGOING,
-    firebase: getOngoingRequestFunc,
+    firebase: getOngoingPostFunc,
     payload,
   });
 
-export const getFinishedRequests = (payload: IgetOpenRequests) => (
+export const getFinishedRequests = (payload: IgetOpenPosts) => (
   dispatch: Function,
 ) =>
   dispatch({
@@ -61,7 +59,7 @@ export const getFinishedRequests = (payload: IgetOpenRequests) => (
     payload,
   });
 
-export const getArchivedRequests = (payload: IgetOpenRequests) => (
+export const getArchivedRequests = (payload: IgetOpenPosts) => (
   dispatch: Function,
 ) =>
   dispatch({
@@ -70,20 +68,20 @@ export const getArchivedRequests = (payload: IgetOpenRequests) => (
     payload,
   });
 
-export const observeOpenRequests = (
+export const observeOpenPosts = (
   dispatch: Function,
-  payload: IgetOpenRequests,
+  payload: IgetOpenPosts,
 ): (() => void) => {
   dispatch({
-    type: OBSERVE_OPEN_REQUESTS,
-    observer: observeOpenRequestsFunc,
+    type: OBSERVE_OPEN_POSTS,
+    observer: observeOpenPostsFunc,
     payload,
   });
 
   return () =>
     dispatch({
-      type: OBSERVE_OPEN_REQUESTS.UNSUBSCRIBE,
-      observerName: OBSERVE_OPEN_REQUESTS,
+      type: OBSERVE_OPEN_POSTS.UNSUBSCRIBE,
+      observerName: OBSERVE_OPEN_POSTS,
     });
 };
 

--- a/web-client/src/ducks/requests/functions.ts
+++ b/web-client/src/ducks/requests/functions.ts
@@ -8,11 +8,11 @@ import {
 import { AbstractRequestStatus } from 'src/models/requests/RequestWithOffersAndTimeline';
 import { ApplicationPreference } from 'src/models/users';
 
-import { IgetOpenRequests } from './types';
+import { IgetOpenPosts } from './types';
 
-export const observeOpenRequests = (
+export const observeOpenPosts = (
   nextValue: Function,
-  payload: IgetOpenRequests,
+  payload: IgetOpenPosts,
 ): firebase.Unsubscribe => {
   let initialQuery = firestore
     .collection('requests')
@@ -51,7 +51,7 @@ export const setUserRequest = async ({
     .withConverter(RequestFirestoreConverter)
     .set(requestPayload);
 
-export const getOpenRequest = async ({ lat, lng }: IgetOpenRequests) =>
+export const getOpenPost = async ({ lat, lng }: IgetOpenPosts) =>
   functions.httpsCallable('https-api-requests-getRequests')({
     lat,
     lng,
@@ -59,7 +59,7 @@ export const getOpenRequest = async ({ lat, lng }: IgetOpenRequests) =>
     status: AbstractRequestStatus.pending,
   });
 
-export const getAcceptedRequest = async ({ lat, lng }: IgetOpenRequests) =>
+export const getAcceptedPost = async ({ lat, lng }: IgetOpenPosts) =>
   functions.httpsCallable('https-api-requests-getRequests')({
     lat,
     lng,
@@ -67,7 +67,7 @@ export const getAcceptedRequest = async ({ lat, lng }: IgetOpenRequests) =>
     status: AbstractRequestStatus.accepted,
   });
 
-export const getOngoingRequest = async ({ lat, lng }: IgetOpenRequests) =>
+export const getOngoingPost = async ({ lat, lng }: IgetOpenPosts) =>
   functions.httpsCallable('https-api-requests-getRequests')({
     lat,
     lng,
@@ -75,7 +75,7 @@ export const getOngoingRequest = async ({ lat, lng }: IgetOpenRequests) =>
     status: AbstractRequestStatus.ongoing,
   });
 
-export const getFinishedRequest = async ({ lat, lng }: IgetOpenRequests) =>
+export const getFinishedRequest = async ({ lat, lng }: IgetOpenPosts) =>
   functions.httpsCallable('https-api-requests-getRequests')({
     lat,
     lng,
@@ -83,7 +83,7 @@ export const getFinishedRequest = async ({ lat, lng }: IgetOpenRequests) =>
     status: AbstractRequestStatus.finished,
   });
 
-export const getArchivedRequest = async ({ lat, lng }: IgetOpenRequests) =>
+export const getArchivedRequest = async ({ lat, lng }: IgetOpenPosts) =>
   functions.httpsCallable('https-api-requests-getRequests')({
     lat,
     lng,

--- a/web-client/src/ducks/requests/reducer.ts
+++ b/web-client/src/ducks/requests/reducer.ts
@@ -7,17 +7,17 @@ import createReducer from 'src/store/utils/createReducer';
 
 import {
   CHANGE_MODAL,
-  GET_ACCEPTED,
   GET_ARCHIVED,
   GET_FINISHED,
+  GET_OFFER_POST,
   GET_ONGOING,
-  GET_OPEN,
-  OBSERVE_CANCELLED_REQUESTS,
-  OBSERVE_COMPLETED_REQUESTS,
-  OBSERVE_ONGOING_REQUESTS,
-  OBSERVE_OPEN_REQUESTS,
-  OBSERVE_REMOVED_REQUESTS,
-  RequestState,
+  GET_REQUEST_POST,
+  OBSERVE_CANCELLED_POSTS,
+  OBSERVE_COMPLETED_POSTS,
+  OBSERVE_ONGOING_POSTS,
+  OBSERVE_OPEN_POSTS,
+  OBSERVE_REMOVED_POSTS,
+  PostState,
   RESET_SET,
   SET,
   SET_TEMP_REQUEST,
@@ -30,44 +30,44 @@ const initialSetActionState = {
   modalState: false,
 };
 
-const initialRequestsState = {
+const initialPostsState = {
   loading: false,
   observerReceivedFirstUpdate: false,
   data: undefined,
   error: undefined,
 };
 
-const initialSyncRequestsState = {
+const initialSyncPostsState = {
   loading: false,
   data: undefined,
   error: undefined,
 };
 
-const initialState: RequestState = {
-  syncOpenRequestsState: initialSyncRequestsState,
-  syncAcceptedRequestsState: initialSyncRequestsState,
-  syncOngoingRequestsState: initialSyncRequestsState,
-  syncArchivedRequestsState: initialSyncRequestsState,
-  syncFinishedRequestsState: initialSyncRequestsState,
-  openRequests: initialRequestsState,
-  ongoingRequests: initialRequestsState,
-  completedRequests: initialRequestsState,
-  cancelledRequests: initialRequestsState,
-  removedRequests: initialRequestsState,
+const initialState: PostState = {
+  syncRequestPostsState: initialSyncPostsState,
+  syncOfferPostsState: initialSyncPostsState,
+  syncOngoingRequestsState: initialSyncPostsState,
+  syncArchivedRequestsState: initialSyncPostsState,
+  syncFinishedRequestsState: initialSyncPostsState,
+  openRequests: initialPostsState,
+  ongoingRequests: initialPostsState,
+  completedRequests: initialPostsState,
+  cancelledRequests: initialPostsState,
+  removedRequests: initialPostsState,
   setAction: initialSetActionState,
   newRequestTemp: undefined,
 };
 
-const requestStatusMapper = {
+const postStatusMapper = {
   [RequestStatus.pending]: 'openRequests',
   [RequestStatus.ongoing]: 'ongoingRequests',
   [RequestStatus.completed]: 'completedRequests',
   [RequestStatus.cancelled]: 'cancelledRequests',
   [RequestStatus.removed]: 'removedRequests',
 };
-const updateRequestState = (state: RequestState, payload) => {
+const updateRequestState = (state: PostState, payload) => {
   state[
-    requestStatusMapper[payload.requestStatus]
+    postStatusMapper[payload.requestStatus]
   ].data = payload.snap.docs.reduce(
     (acc, doc) => ({
       ...acc,
@@ -75,20 +75,20 @@ const updateRequestState = (state: RequestState, payload) => {
     }),
     {},
   );
-  state[requestStatusMapper[payload.requestStatus]].loading = false;
+  state[postStatusMapper[payload.requestStatus]].loading = false;
   state[
-    requestStatusMapper[payload.requestStatus]
+    postStatusMapper[payload.requestStatus]
   ].observerReceivedFirstUpdate = true;
 };
 
-export default createReducer<RequestState>(
+export default createReducer<PostState>(
   {
-    [GET_OPEN.PENDING]: (state: RequestState) => {
-      state.syncOpenRequestsState.loading = true;
-      state.syncOpenRequestsState.data = undefined;
+    [GET_REQUEST_POST.PENDING]: (state: PostState) => {
+      state.syncRequestPostsState.loading = true;
+      state.syncRequestPostsState.data = undefined;
     },
-    [GET_OPEN.COMPLETED]: (
-      state: RequestState,
+    [GET_REQUEST_POST.COMPLETED]: (
+      state: PostState,
       {
         payload,
       }: {
@@ -100,8 +100,8 @@ export default createReducer<RequestState>(
         };
       },
     ) => {
-      state.syncOpenRequestsState.loading = false;
-      state.syncOpenRequestsState.error = undefined;
+      state.syncRequestPostsState.loading = false;
+      state.syncRequestPostsState.error = undefined;
       const mappedData = Object.keys(payload.data.data).reduce(
         (acc: Record<string, RequestWithOffersAndTimeline>, key: string) => ({
           ...acc,
@@ -109,22 +109,22 @@ export default createReducer<RequestState>(
         }),
         {},
       );
-      state.syncOpenRequestsState.data = mappedData;
+      state.syncRequestPostsState.data = mappedData;
     },
-    [GET_OPEN.REJECTED]: (
-      state: RequestState,
+    [GET_REQUEST_POST.REJECTED]: (
+      state: PostState,
       { payload }: { payload: Error },
     ) => {
-      state.syncOpenRequestsState.data = undefined;
-      state.syncOpenRequestsState.loading = false;
-      state.syncOpenRequestsState.error = payload;
+      state.syncRequestPostsState.data = undefined;
+      state.syncRequestPostsState.loading = false;
+      state.syncRequestPostsState.error = payload;
     },
-    [GET_ACCEPTED.PENDING]: (state: RequestState) => {
-      state.syncAcceptedRequestsState.loading = true;
-      state.syncAcceptedRequestsState.data = undefined;
+    [GET_OFFER_POST.PENDING]: (state: PostState) => {
+      state.syncOfferPostsState.loading = true;
+      state.syncOfferPostsState.data = undefined;
     },
-    [GET_ACCEPTED.COMPLETED]: (
-      state: RequestState,
+    [GET_OFFER_POST.COMPLETED]: (
+      state: PostState,
       {
         payload,
       }: {
@@ -136,11 +136,9 @@ export default createReducer<RequestState>(
         };
       },
     ) => {
-      state.syncAcceptedRequestsState.loading = false;
-      state.syncAcceptedRequestsState.error = undefined;
-      state.syncAcceptedRequestsState.data = Object.keys(
-        payload.data.data,
-      ).reduce(
+      state.syncOfferPostsState.loading = false;
+      state.syncOfferPostsState.error = undefined;
+      state.syncOfferPostsState.data = Object.keys(payload.data.data).reduce(
         (acc: Record<string, RequestWithOffersAndTimeline>, key: string) => ({
           ...acc,
           [key]: RequestWithOffersAndTimeline.factory(payload.data.data[key]),
@@ -148,20 +146,20 @@ export default createReducer<RequestState>(
         {},
       );
     },
-    [GET_ACCEPTED.REJECTED]: (
-      state: RequestState,
+    [GET_OFFER_POST.REJECTED]: (
+      state: PostState,
       { payload }: { payload: Error },
     ) => {
-      state.syncAcceptedRequestsState.data = undefined;
-      state.syncAcceptedRequestsState.loading = false;
-      state.syncAcceptedRequestsState.error = payload;
+      state.syncOfferPostsState.data = undefined;
+      state.syncOfferPostsState.loading = false;
+      state.syncOfferPostsState.error = payload;
     },
-    [GET_ARCHIVED.PENDING]: (state: RequestState) => {
+    [GET_ARCHIVED.PENDING]: (state: PostState) => {
       state.syncArchivedRequestsState.loading = true;
       state.syncArchivedRequestsState.data = undefined;
     },
     [GET_ARCHIVED.COMPLETED]: (
-      state: RequestState,
+      state: PostState,
       {
         payload,
       }: {
@@ -186,19 +184,19 @@ export default createReducer<RequestState>(
       );
     },
     [GET_ARCHIVED.REJECTED]: (
-      state: RequestState,
+      state: PostState,
       { payload }: { payload: Error },
     ) => {
       state.syncArchivedRequestsState.data = undefined;
       state.syncArchivedRequestsState.loading = false;
       state.syncArchivedRequestsState.error = payload;
     },
-    [GET_FINISHED.PENDING]: (state: RequestState) => {
+    [GET_FINISHED.PENDING]: (state: PostState) => {
       state.syncFinishedRequestsState.loading = true;
       state.syncFinishedRequestsState.data = undefined;
     },
     [GET_FINISHED.COMPLETED]: (
-      state: RequestState,
+      state: PostState,
       {
         payload,
       }: {
@@ -223,19 +221,19 @@ export default createReducer<RequestState>(
       );
     },
     [GET_FINISHED.REJECTED]: (
-      state: RequestState,
+      state: PostState,
       { payload }: { payload: Error },
     ) => {
       state.syncFinishedRequestsState.data = undefined;
       state.syncFinishedRequestsState.loading = false;
       state.syncFinishedRequestsState.error = payload;
     },
-    [GET_ONGOING.PENDING]: (state: RequestState) => {
+    [GET_ONGOING.PENDING]: (state: PostState) => {
       state.syncOngoingRequestsState.loading = true;
       state.syncOngoingRequestsState.data = undefined;
     },
     [GET_ONGOING.COMPLETED]: (
-      state: RequestState,
+      state: PostState,
       {
         payload,
       }: {
@@ -260,31 +258,31 @@ export default createReducer<RequestState>(
       );
     },
     [GET_ONGOING.REJECTED]: (
-      state: RequestState,
+      state: PostState,
       { payload }: { payload: Error },
     ) => {
       state.syncOngoingRequestsState.data = undefined;
       state.syncOngoingRequestsState.loading = false;
       state.syncOngoingRequestsState.error = payload;
     },
-    [SET.PENDING]: (state: RequestState) => {
+    [SET.PENDING]: (state: PostState) => {
       state.setAction.loading = true;
       state.setAction.error = undefined;
     },
-    [SET.COMPLETED]: (state: RequestState) => {
+    [SET.COMPLETED]: (state: PostState) => {
       state.setAction.error = undefined;
       state.setAction.loading = false;
       state.setAction.success = true;
       state.newRequestTemp = undefined;
     },
-    [SET.REJECTED]: (state: RequestState, { payload }: { payload: Error }) => {
+    [SET.REJECTED]: (state: PostState, { payload }: { payload: Error }) => {
       state.setAction.loading = false;
       state.setAction.error = payload;
       state.setAction.success = false;
       state.newRequestTemp = undefined;
     },
     [SET_TEMP_REQUEST]: (
-      state: RequestState,
+      state: PostState,
       {
         payload,
       }: {
@@ -296,34 +294,31 @@ export default createReducer<RequestState>(
     ) => {
       state.newRequestTemp = payload;
     },
-    [RESET_SET]: (state: RequestState) => {
+    [RESET_SET]: (state: PostState) => {
       state.setAction.loading = false;
       state.setAction.success = false;
-      state.syncOpenRequestsState.data = undefined;
-      state.syncOpenRequestsState.loading = false;
+      state.syncRequestPostsState.data = undefined;
+      state.syncRequestPostsState.loading = false;
       state.syncOngoingRequestsState.data = undefined;
       state.syncOngoingRequestsState.loading = false;
-      state.syncAcceptedRequestsState.data = undefined;
-      state.syncAcceptedRequestsState.loading = false;
+      state.syncOfferPostsState.data = undefined;
+      state.syncOfferPostsState.loading = false;
       state.syncFinishedRequestsState.data = undefined;
       state.syncFinishedRequestsState.loading = false;
       state.syncArchivedRequestsState.data = undefined;
       state.syncArchivedRequestsState.loading = false;
     },
-    [CHANGE_MODAL]: (
-      state: RequestState,
-      { payload }: { payload: boolean },
-    ) => {
+    [CHANGE_MODAL]: (state: PostState, { payload }: { payload: boolean }) => {
       state.setAction.modalState = payload;
       if (!payload) {
         state.setAction.success = false;
       }
     },
-    [OBSERVE_OPEN_REQUESTS.SUBSCRIBE]: (state: RequestState) => {
+    [OBSERVE_OPEN_POSTS.SUBSCRIBE]: (state: PostState) => {
       state.openRequests.loading = true;
     },
-    [OBSERVE_OPEN_REQUESTS.UPDATED]: (
-      state: RequestState,
+    [OBSERVE_OPEN_POSTS.UPDATED]: (
+      state: PostState,
       {
         payload,
       }: {
@@ -340,18 +335,18 @@ export default createReducer<RequestState>(
       state.openRequests.loading = false;
       state.openRequests.observerReceivedFirstUpdate = true;
     },
-    [OBSERVE_OPEN_REQUESTS.ERROR]: (
-      state: RequestState,
+    [OBSERVE_OPEN_POSTS.ERROR]: (
+      state: PostState,
       { payload }: { payload: Error },
     ) => {
       state.openRequests.error = payload;
       state.openRequests.loading = false;
     },
-    [OBSERVE_ONGOING_REQUESTS.SUBSCRIBE]: (state: RequestState) => {
+    [OBSERVE_ONGOING_POSTS.SUBSCRIBE]: (state: PostState) => {
       state.openRequests.loading = true;
     },
-    [OBSERVE_ONGOING_REQUESTS.UPDATED]: (
-      state: RequestState,
+    [OBSERVE_ONGOING_POSTS.UPDATED]: (
+      state: PostState,
       {
         payload,
       }: {
@@ -361,11 +356,11 @@ export default createReducer<RequestState>(
         };
       },
     ) => updateRequestState(state, payload),
-    [OBSERVE_COMPLETED_REQUESTS.SUBSCRIBE]: (state: RequestState) => {
+    [OBSERVE_COMPLETED_POSTS.SUBSCRIBE]: (state: PostState) => {
       state.completedRequests.loading = true;
     },
-    [OBSERVE_COMPLETED_REQUESTS.UPDATED]: (
-      state: RequestState,
+    [OBSERVE_COMPLETED_POSTS.UPDATED]: (
+      state: PostState,
       {
         payload,
       }: {
@@ -375,11 +370,11 @@ export default createReducer<RequestState>(
         };
       },
     ) => updateRequestState(state, payload),
-    [OBSERVE_CANCELLED_REQUESTS.SUBSCRIBE]: (state: RequestState) => {
+    [OBSERVE_CANCELLED_POSTS.SUBSCRIBE]: (state: PostState) => {
       state.cancelledRequests.loading = true;
     },
-    [OBSERVE_CANCELLED_REQUESTS.UPDATED]: (
-      state: RequestState,
+    [OBSERVE_CANCELLED_POSTS.UPDATED]: (
+      state: PostState,
       {
         payload,
       }: {
@@ -389,11 +384,11 @@ export default createReducer<RequestState>(
         };
       },
     ) => updateRequestState(state, payload),
-    [OBSERVE_REMOVED_REQUESTS.SUBSCRIBE]: (state: RequestState) => {
+    [OBSERVE_REMOVED_POSTS.SUBSCRIBE]: (state: PostState) => {
       state.cancelledRequests.loading = true;
     },
-    [OBSERVE_REMOVED_REQUESTS.UPDATED]: (
-      state: RequestState,
+    [OBSERVE_REMOVED_POSTS.UPDATED]: (
+      state: PostState,
       {
         payload,
       }: {

--- a/web-client/src/ducks/requests/types.ts
+++ b/web-client/src/ducks/requests/types.ts
@@ -1,4 +1,4 @@
-import { Request, RequestStatus } from 'src/models/requests';
+import { Request } from 'src/models/requests';
 import { RequestWithOffersAndTimeline } from 'src/models/requests/RequestWithOffersAndTimeline';
 import { ApplicationPreference, User } from 'src/models/users';
 import createActionTypeFactory from 'src/store/utils/createActionTypeFactory';
@@ -9,29 +9,21 @@ export const { asyncType, observerType, syncType } = createActionTypeFactory(
 
 export const CHANGE_MODAL = syncType('CHANGE_MODAL');
 
-export const OBSERVE_OPEN_REQUESTS = observerType('OBSERVE_OPEN_REQUESTS');
+export const OBSERVE_OPEN_POSTS = observerType('OBSERVE_OPEN_POSTS');
 
-export const OBSERVE_ONGOING_REQUESTS = observerType(
-  'OBSERVE_ONGOING_REQUESTS',
-);
+export const OBSERVE_ONGOING_POSTS = observerType('OBSERVE_ONGOING_POSTS');
 
-export const OBSERVE_COMPLETED_REQUESTS = observerType(
-  'OBSERVE_COMPLETED_REQUESTS',
-);
+export const OBSERVE_COMPLETED_POSTS = observerType('OBSERVE_COMPLETED_POSTS');
 
-export const OBSERVE_CANCELLED_REQUESTS = observerType(
-  'OBSERVE_CANCELLED_REQUESTS',
-);
+export const OBSERVE_CANCELLED_POSTS = observerType('OBSERVE_CANCELLED_POSTS');
 
-export const OBSERVE_REMOVED_REQUESTS = observerType(
-  'OBSERVE_REMOVED_REQUESTS',
-);
+export const OBSERVE_REMOVED_POSTS = observerType('OBSERVE_REMOVED_POSTS');
 
 export const SET = asyncType('SET');
 export const RESET_SET = syncType('RESET_SET');
 
-export const GET_OPEN = asyncType('GET_OPEN');
-export const GET_ACCEPTED = asyncType('GET_ACCEPTED');
+export const GET_REQUEST_POST = asyncType('GET_REQUEST_POST');
+export const GET_OFFER_POST = asyncType('GET_OFFER_POST');
 export const GET_ONGOING = asyncType('GET_ONGOING');
 export const GET_FINISHED = asyncType('GET_FINISHED');
 export const GET_ARCHIVED = asyncType('GET_ARCHIVED');
@@ -40,13 +32,13 @@ export const UPDATE = asyncType('UPDATE');
 
 export const SET_TEMP_REQUEST = syncType('SET_TEMP_REQUEST');
 
-export interface RequestState {
-  syncOpenRequestsState: {
+export interface PostState {
+  syncRequestPostsState: {
     loading: boolean;
     data?: Record<string, RequestWithOffersAndTimeline>;
     error?: Error;
   };
-  syncAcceptedRequestsState: {
+  syncOfferPostsState: {
     loading: boolean;
     data?: Record<string, RequestWithOffersAndTimeline>;
     error?: Error;
@@ -108,15 +100,9 @@ export interface RequestState {
   };
 }
 
-export interface IgetOpenRequests {
+export interface IgetOpenPosts {
   userRef?: firebase.firestore.DocumentReference<User>;
   lat?: number;
   lng?: number;
   userType: ApplicationPreference;
-}
-
-export interface IgetNonOpenRequests {
-  userRef: firebase.firestore.DocumentReference<User>;
-  userType: ApplicationPreference;
-  requestStatus: RequestStatus;
 }

--- a/web-client/src/models/users/index.ts
+++ b/web-client/src/models/users/index.ts
@@ -55,6 +55,7 @@ export class User implements IUser {
     displayName: string | null = null,
     displayPicture: string | null = null,
     createdAt = firestore.Timestamp.now(),
+    url = '',
   ) {
     this._cavQuestionnaireRef = cavQuestionnaireRef;
     this._pinQuestionnaireRef = pinQuestionnaireRef;
@@ -68,6 +69,7 @@ export class User implements IUser {
     this._displayPicture = displayPicture;
     this._applicationPreference = applicationPreference;
     this._createdAt = createdAt;
+    this._url = url;
   }
 
   @IsObject()
@@ -194,6 +196,18 @@ export class User implements IUser {
 
   set displayName(value: string | null) {
     this._displayName = value;
+  }
+
+  @IsString()
+  @IsOptional()
+  private _url: string | null;
+
+  get url(): string | null {
+    return this._url;
+  }
+
+  set url(value: string | null) {
+    this._url = value;
   }
 
   @IsUrl()

--- a/web-client/src/modules/create/containers/CreatePostContainer.tsx
+++ b/web-client/src/modules/create/containers/CreatePostContainer.tsx
@@ -15,7 +15,7 @@ import {
 import Map from 'src/components/WebClientMap/WebClientMap';
 import { ProfileState } from 'src/ducks/profile/types';
 import { resetSetRequestState, setRequest } from 'src/ducks/requests/actions';
-import { RequestState } from 'src/ducks/requests/types';
+import { PostState } from 'src/ducks/requests/types';
 import { IRequest, Request } from 'src/models/requests';
 import { IUser } from 'src/models/users';
 import { MyRequestPostsLocationUrl } from 'src/modules/requests/constants';
@@ -102,11 +102,11 @@ const CreatePostContainer: React.FC<ICreatePostContainer> = () => {
   );
 
   const newRequestState = useSelector(
-    ({ requests }: { requests: RequestState }) => requests.setAction,
+    ({ requests }: { requests: PostState }) => requests.setAction,
   );
 
   const newRequestTemp = useSelector(
-    ({ requests }: { requests: RequestState }) => requests.newRequestTemp,
+    ({ requests }: { requests: PostState }) => requests.newRequestTemp,
   );
 
   const dispatch = useDispatch();

--- a/web-client/src/modules/requests/containers/AcceptedRequestsContainer.tsx
+++ b/web-client/src/modules/requests/containers/AcceptedRequestsContainer.tsx
@@ -4,10 +4,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { ProfileState } from 'src/ducks/profile/types';
 import {
-  getAcceptedRequests,
+  getAcceptedPosts,
   resetSetRequestState,
 } from 'src/ducks/requests/actions';
-import { RequestState } from 'src/ducks/requests/types';
+import { PostState } from 'src/ducks/requests/types';
 import { ApplicationPreference } from 'src/models/users';
 import { TimelineAcceptedViewLocation } from 'src/modules/timeline/constants';
 
@@ -29,8 +29,7 @@ const OpenRequestsContainer: React.FC = () => {
   );
 
   const acceptedRequestsWithOffersAndTimeline = useSelector(
-    ({ requests }: { requests: RequestState }) =>
-      requests.syncAcceptedRequestsState,
+    ({ requests }: { requests: PostState }) => requests.syncOfferPostsState,
   );
 
   useEffect(() => {
@@ -40,7 +39,7 @@ const OpenRequestsContainer: React.FC = () => {
   useEffect(() => {
     if (profileState.profile && profileState.profile.applicationPreference) {
       dispatch(
-        getAcceptedRequests({
+        getAcceptedPosts({
           userType: profileState.profile.applicationPreference,
           userRef: profileState.userRef,
         }),

--- a/web-client/src/modules/requests/containers/FindRequestsContainer.tsx
+++ b/web-client/src/modules/requests/containers/FindRequestsContainer.tsx
@@ -17,11 +17,8 @@ import Map from 'src/components/WebClientMap/WebClientMap';
 import { resetSetOfferState, setOffer } from 'src/ducks/offers/actions';
 import { OffersState } from 'src/ducks/offers/types';
 import { ProfileState } from 'src/ducks/profile/types';
-import {
-  getOpenRequests,
-  resetSetRequestState,
-} from 'src/ducks/requests/actions';
-import { RequestState } from 'src/ducks/requests/types';
+import { getOpenPosts, resetSetRequestState } from 'src/ducks/requests/actions';
+import { PostState } from 'src/ducks/requests/types';
 import { firestore } from 'src/firebase';
 import { Offer, OfferStatus } from 'src/models/offers';
 import { RequestWithOffersAndTimeline } from 'src/models/requests/RequestWithOffersAndTimeline';
@@ -66,8 +63,7 @@ const FindRequestsContainer: React.FC = () => {
   const [authModalIsVisible, setAuthModalIsVisible] = useState<boolean>(false);
 
   const pendingRequestsWithOffersAndTimeline = useSelector(
-    ({ requests }: { requests: RequestState }) =>
-      requests.syncOpenRequestsState,
+    ({ requests }: { requests: PostState }) => requests.syncRequestPostsState,
   );
 
   const setOfferState = useSelector(
@@ -142,7 +138,7 @@ const FindRequestsContainer: React.FC = () => {
             Object.keys(profileState.privilegedInformation.addresses)[0]
           ];
       dispatch(
-        getOpenRequests({
+        getOpenPosts({
           userType: profileState.profile.applicationPreference,
           userRef: profileState.userRef,
           lat: addressToUse?.coords.latitude || 0,

--- a/web-client/src/modules/requests/containers/OfferPostsContainer.tsx
+++ b/web-client/src/modules/requests/containers/OfferPostsContainer.tsx
@@ -1,10 +1,103 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { ProfileState } from 'src/ducks/profile/types';
+// TODO: reset - what is it used for
+import {
+  getAcceptedRequests,
+  resetSetRequestState,
+} from 'src/ducks/requests/actions';
+import { RequestState } from 'src/ducks/requests/types';
+import { ApplicationPreference } from 'src/models/users';
+import { TimelineAcceptedViewLocation } from 'src/modules/timeline/constants';
 
-import { PostTabsType } from '../constants';
-import PostsContainer from './PostsContainer';
+import LoadingWrapper from '../../../components/LoadingComponent/LoadingComponent';
+import {
+  InformationModal,
+  makeLocalStorageKey,
+} from '../../../components/Modals/OneTimeModal';
+import AcceptedRequestItem from '../components/AcceptedRequestItem';
+import Header from '../components/Header';
+import RequestList from '../components/RequestList';
 
-const OfferPostsContainer: React.FC = () => (
-  <PostsContainer postType={PostTabsType.offers} />
-);
+const OfferPostsContainer: React.FC = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const profileState = useSelector(
+    ({ profile }: { profile: ProfileState }) => profile,
+  );
+
+  const acceptedRequestsWithOffersAndTimeline = useSelector(
+    ({ requests }: { requests: RequestState }) =>
+      requests.syncAcceptedRequestsState,
+  );
+
+  useEffect(() => {
+    dispatch(resetSetRequestState());
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (profileState.profile && profileState.profile.applicationPreference) {
+      dispatch(
+        getAcceptedRequests({
+          userType: profileState.profile.applicationPreference,
+          userRef: profileState.userRef,
+        }),
+      );
+    }
+  }, [profileState, dispatch]);
+
+  const handleRequest: Function = id =>
+    history.push(TimelineAcceptedViewLocation.toUrl({ requestId: id }));
+
+  if (
+    !acceptedRequestsWithOffersAndTimeline.data ||
+    acceptedRequestsWithOffersAndTimeline.loading
+  ) {
+    return <LoadingWrapper />;
+  }
+  const instructions = [
+    t('information_modal.AcceptedRequestsContainer.0'),
+    t('information_modal.AcceptedRequestsContainer.1'),
+  ];
+  const instructionModalLocalStorageKey = makeLocalStorageKey({
+    prefix: 'reach4help.modalSeen.AcceptedRequestsContainer',
+    userid: profileState.uid,
+  });
+
+  return (
+    <>
+      <Header
+        requestsType={t(
+          'modules.requests.containers.AcceptedRequestContainer.accepted',
+        )}
+        numRequests={
+          Object.keys(acceptedRequestsWithOffersAndTimeline.data || {}).length
+        }
+        isCav={
+          profileState.profile?.applicationPreference ===
+          ApplicationPreference.cav
+        }
+        isAcceptedRequests
+      />
+      <RequestList
+        requests={acceptedRequestsWithOffersAndTimeline.data}
+        loading={
+          acceptedRequestsWithOffersAndTimeline &&
+          acceptedRequestsWithOffersAndTimeline.loading
+        }
+        handleRequest={handleRequest}
+        RequestItem={AcceptedRequestItem}
+      />
+      <InformationModal
+        title={t('information_modal.AcceptedRequestsContainer.title')}
+        localStorageKey={instructionModalLocalStorageKey}
+        instructions={instructions}
+      />
+    </>
+  );
+};
 
 export default OfferPostsContainer;

--- a/web-client/src/modules/requests/containers/OfferPostsContainer.tsx
+++ b/web-client/src/modules/requests/containers/OfferPostsContainer.tsx
@@ -34,9 +34,10 @@ const OfferPostsContainer: React.FC = () => {
       requests.syncAcceptedRequestsState,
   );
 
+  const url = profileState.profile?.url;
   useEffect(() => {
     dispatch(resetSetRequestState());
-  }, [dispatch]);
+  }, [url, dispatch]);
 
   useEffect(() => {
     if (profileState.profile && profileState.profile.applicationPreference) {
@@ -47,7 +48,7 @@ const OfferPostsContainer: React.FC = () => {
         }),
       );
     }
-  }, [profileState, dispatch]);
+  }, [url, profileState, dispatch]);
 
   const handleRequest: Function = id =>
     history.push(TimelineAcceptedViewLocation.toUrl({ requestId: id }));

--- a/web-client/src/modules/requests/containers/OfferPostsContainer.tsx
+++ b/web-client/src/modules/requests/containers/OfferPostsContainer.tsx
@@ -5,10 +5,10 @@ import { useHistory } from 'react-router-dom';
 import { ProfileState } from 'src/ducks/profile/types';
 // TODO: reset - what is it used for
 import {
-  getAcceptedRequests,
+  getAcceptedPosts,
   resetSetRequestState,
 } from 'src/ducks/requests/actions';
-import { RequestState } from 'src/ducks/requests/types';
+import { PostState } from 'src/ducks/requests/types';
 import { ApplicationPreference } from 'src/models/users';
 import { TimelineAcceptedViewLocation } from 'src/modules/timeline/constants';
 
@@ -30,8 +30,7 @@ const OfferPostsContainer: React.FC = () => {
   );
 
   const acceptedRequestsWithOffersAndTimeline = useSelector(
-    ({ requests }: { requests: RequestState }) =>
-      requests.syncAcceptedRequestsState,
+    ({ requests }: { requests: PostState }) => requests.syncOfferPostsState,
   );
 
   const url = profileState.profile?.url;
@@ -42,7 +41,7 @@ const OfferPostsContainer: React.FC = () => {
   useEffect(() => {
     if (profileState.profile && profileState.profile.applicationPreference) {
       dispatch(
-        getAcceptedRequests({
+        getAcceptedPosts({
           userType: profileState.profile.applicationPreference,
           userRef: profileState.userRef,
         }),

--- a/web-client/src/modules/requests/containers/OpenRequestsContainer.tsx
+++ b/web-client/src/modules/requests/containers/OpenRequestsContainer.tsx
@@ -4,11 +4,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { ProfileState } from 'src/ducks/profile/types';
 import {
-  getAcceptedRequests,
-  getOpenRequests,
+  getAcceptedPosts,
+  getOpenPosts,
   resetSetRequestState,
 } from 'src/ducks/requests/actions';
-import { RequestState } from 'src/ducks/requests/types';
+import { PostState } from 'src/ducks/requests/types';
 import { ApplicationPreference } from 'src/models/users';
 import { TimelineViewLocation } from 'src/modules/timeline/constants';
 
@@ -31,14 +31,14 @@ const OpenRequestsContainer: React.FC = () => {
   );
 
   const requestWithOffersAndTimeline = useSelector(
-    ({ requests }: { requests: RequestState }) => {
+    ({ requests }: { requests: PostState }) => {
       if (
         profileState.profile?.applicationPreference ===
         ApplicationPreference.cav
       ) {
-        return requests.syncAcceptedRequestsState;
+        return requests.syncOfferPostsState;
       }
-      return requests.syncOpenRequestsState;
+      return requests.syncRequestPostsState;
     },
   );
 
@@ -52,14 +52,14 @@ const OpenRequestsContainer: React.FC = () => {
         profileState.profile.applicationPreference === ApplicationPreference.cav
       ) {
         dispatch(
-          getAcceptedRequests({
+          getAcceptedPosts({
             userType: profileState.profile.applicationPreference,
             userRef: profileState.userRef,
           }),
         );
       } else {
         dispatch(
-          getOpenRequests({
+          getOpenPosts({
             userType: profileState.profile.applicationPreference,
             userRef: profileState.userRef,
           }),

--- a/web-client/src/modules/requests/containers/PostsContainer.tsx
+++ b/web-client/src/modules/requests/containers/PostsContainer.tsx
@@ -4,11 +4,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { ProfileState } from 'src/ducks/profile/types';
 import {
-  getAcceptedRequests,
-  getOpenRequests,
+  getAcceptedPosts,
+  getOpenPosts,
   resetSetRequestState,
 } from 'src/ducks/requests/actions';
-import { RequestState } from 'src/ducks/requests/types';
+import { PostState } from 'src/ducks/requests/types';
 import { ApplicationPreference } from 'src/models/users';
 import { TimelineViewLocation } from 'src/modules/timeline/constants';
 
@@ -37,10 +37,8 @@ const PostsContainer: React.FC<PostsProps> = ({
   );
 
   const requestWithOffersAndTimeline = useSelector(
-    ({ requests }: { requests: RequestState }) =>
-      isOffers
-        ? requests.syncAcceptedRequestsState
-        : requests.syncOpenRequestsState,
+    ({ requests }: { requests: PostState }) =>
+      isOffers ? requests.syncOfferPostsState : requests.syncRequestPostsState,
   );
 
   const instructions = [
@@ -69,14 +67,14 @@ const PostsContainer: React.FC<PostsProps> = ({
   useEffect(() => {
     if (isOffers) {
       dispatch(
-        getAcceptedRequests({
+        getAcceptedPosts({
           userType: ApplicationPreference.cav,
           userRef: profileState.userRef,
         }),
       );
     } else {
       dispatch(
-        getOpenRequests({
+        getOpenPosts({
           userType: ApplicationPreference.pin,
           userRef: profileState.userRef,
         }),

--- a/web-client/src/modules/requests/containers/RequestPostsContainer.tsx
+++ b/web-client/src/modules/requests/containers/RequestPostsContainer.tsx
@@ -3,11 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { ProfileState } from 'src/ducks/profile/types';
-import {
-  getOpenRequests,
-  resetSetRequestState,
-} from 'src/ducks/requests/actions';
-import { RequestState } from 'src/ducks/requests/types';
+import { getOpenPosts, resetSetRequestState } from 'src/ducks/requests/actions';
+import { PostState } from 'src/ducks/requests/types';
 import { ApplicationPreference } from 'src/models/users';
 import { TimelineViewLocation } from 'src/modules/timeline/constants';
 
@@ -33,14 +30,14 @@ const OpenRequestsContainer: React.FC = () => {
   // console.log('after', profileState.url);
 
   const requestWithOffersAndTimeline = useSelector(
-    ({ requests }: { requests: RequestState }) => {
+    ({ requests }: { requests: PostState }) => {
       if (
         profileState.profile?.applicationPreference ===
         ApplicationPreference.cav
       ) {
-        return requests.syncAcceptedRequestsState;
+        return requests.syncOfferPostsState;
       }
-      return requests.syncOpenRequestsState;
+      return requests.syncRequestPostsState;
     },
   );
 
@@ -53,7 +50,7 @@ const OpenRequestsContainer: React.FC = () => {
   useEffect(() => {
     if (profileState.profile?.applicationPreference) {
       dispatch(
-        getOpenRequests({
+        getOpenPosts({
           userType: profileState.profile.applicationPreference,
           userRef: profileState.userRef,
         }),

--- a/web-client/src/modules/requests/containers/RequestPostsContainer.tsx
+++ b/web-client/src/modules/requests/containers/RequestPostsContainer.tsx
@@ -4,7 +4,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { ProfileState } from 'src/ducks/profile/types';
 import {
-  getAcceptedRequests,
   getOpenRequests,
   resetSetRequestState,
 } from 'src/ducks/requests/actions';
@@ -44,34 +43,23 @@ const OpenRequestsContainer: React.FC = () => {
       return requests.syncOpenRequestsState;
     },
   );
-  const pref = profileState.profile?.applicationPreference;
-  useEffect(() => {
-    if (profileState.profile?.applicationPreference === ApplicationPreference.pin) {
-      dispatch(resetSetRequestState());
-    }
-  }, [profileState.profile, pref, dispatch]);
+
+  const url = profileState.profile?.url;
 
   useEffect(() => {
-    if (profileState.profile && profileState.profile.applicationPreference) {
-      if (
-        profileState.profile.applicationPreference === ApplicationPreference.cav
-      ) {
-        dispatch(
-          getAcceptedRequests({
-            userType: profileState.profile.applicationPreference,
-            userRef: profileState.userRef,
-          }),
-        );
-      } else {
-        dispatch(
-          getOpenRequests({
-            userType: profileState.profile.applicationPreference,
-            userRef: profileState.userRef,
-          }),
-        );
-      }
+    dispatch(resetSetRequestState());
+  }, [url, dispatch]);
+
+  useEffect(() => {
+    if (profileState.profile?.applicationPreference) {
+      dispatch(
+        getOpenRequests({
+          userType: profileState.profile.applicationPreference,
+          userRef: profileState.userRef,
+        }),
+      );
     }
-  }, [profileState, pref, dispatch]);
+  }, [profileState, url, dispatch]);
 
   const handleRequest: Function = id =>
     history.push(TimelineViewLocation.toUrl({ requestId: id }));

--- a/web-client/src/modules/requests/containers/RequestPostsContainer.tsx
+++ b/web-client/src/modules/requests/containers/RequestPostsContainer.tsx
@@ -1,10 +1,136 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { ProfileState } from 'src/ducks/profile/types';
+import {
+  getAcceptedRequests,
+  getOpenRequests,
+  resetSetRequestState,
+} from 'src/ducks/requests/actions';
+import { RequestState } from 'src/ducks/requests/types';
+import { ApplicationPreference } from 'src/models/users';
+import { TimelineViewLocation } from 'src/modules/timeline/constants';
 
-import { PostTabsType } from '../constants';
-import PostsContainer from './PostsContainer';
+import LoadingWrapper from '../../../components/LoadingComponent/LoadingComponent';
+import {
+  InformationModal,
+  makeLocalStorageKey,
+} from '../../../components/Modals/OneTimeModal';
+import Header from '../components/Header';
+import RequestItem from '../components/RequestItem';
+import RequestList from '../components/RequestList';
 
-const RequestPostsContainer: React.FC = () => (
-  <PostsContainer postType={PostTabsType.requests} />
-);
+const OpenRequestsContainer: React.FC = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const history = useHistory();
 
-export default RequestPostsContainer;
+  const profileState = useSelector(
+    ({ profile }: { profile: ProfileState }) => profile,
+  );
+  // TODO: console.log('before', profileState.url);
+  // profileState.url = window.location.href;
+  // console.log('after', profileState.url);
+
+  const requestWithOffersAndTimeline = useSelector(
+    ({ requests }: { requests: RequestState }) => {
+      if (
+        profileState.profile?.applicationPreference ===
+        ApplicationPreference.cav
+      ) {
+        return requests.syncAcceptedRequestsState;
+      }
+      return requests.syncOpenRequestsState;
+    },
+  );
+  const pref = profileState.profile?.applicationPreference;
+  useEffect(() => {
+    if (profileState.profile?.applicationPreference === ApplicationPreference.pin) {
+      dispatch(resetSetRequestState());
+    }
+  }, [profileState.profile, pref, dispatch]);
+
+  useEffect(() => {
+    if (profileState.profile && profileState.profile.applicationPreference) {
+      if (
+        profileState.profile.applicationPreference === ApplicationPreference.cav
+      ) {
+        dispatch(
+          getAcceptedRequests({
+            userType: profileState.profile.applicationPreference,
+            userRef: profileState.userRef,
+          }),
+        );
+      } else {
+        dispatch(
+          getOpenRequests({
+            userType: profileState.profile.applicationPreference,
+            userRef: profileState.userRef,
+          }),
+        );
+      }
+    }
+  }, [profileState, pref, dispatch]);
+
+  const handleRequest: Function = id =>
+    history.push(TimelineViewLocation.toUrl({ requestId: id }));
+
+  const toCloseRequest: Function = id => `Fill logic: Remove request ${id}`;
+
+  if (
+    !requestWithOffersAndTimeline.data ||
+    requestWithOffersAndTimeline.loading
+  ) {
+    return <LoadingWrapper />;
+  }
+
+  const instructions = [
+    t('information_modal.OpenRequestsContainer.0'),
+    t('information_modal.OpenRequestsContainer.1'),
+    t('information_modal.OpenRequestsContainer.2'),
+  ];
+  const instructionModalLocalStorageKey = makeLocalStorageKey({
+    prefix: 'reach4help.modalSeen.OpenRequestsContainer',
+    userid: profileState.uid,
+  });
+
+  return (
+    <>
+      <Header
+        requestsType={t(
+          'modules.requests.containers.OpenRequestContainer.open',
+        )}
+        numRequests={
+          Object.keys(requestWithOffersAndTimeline.data || {}).length
+        }
+        isCav={
+          profileState.profile?.applicationPreference ===
+          ApplicationPreference.cav
+        }
+        isAcceptedRequests={false}
+      />
+      <RequestList
+        requests={requestWithOffersAndTimeline.data}
+        loading={
+          requestWithOffersAndTimeline && requestWithOffersAndTimeline.loading
+        }
+        handleRequest={handleRequest}
+        isCavAndOpenRequest={false}
+        isPinAndOpenRequest={
+          profileState.profile?.applicationPreference ===
+          ApplicationPreference.pin
+        }
+        RequestItem={RequestItem}
+        toCloseRequest={toCloseRequest}
+      />
+      <InformationModal
+        title={t('information_modal.OpenRequestsContainer.title')}
+        localStorageKey={instructionModalLocalStorageKey}
+        instructions={instructions}
+      />
+    </>
+  );
+};
+
+export default OpenRequestsContainer;

--- a/web-client/src/modules/requests/pages/TabbedPostsPage.tsx
+++ b/web-client/src/modules/requests/pages/TabbedPostsPage.tsx
@@ -1,7 +1,10 @@
 import { Tabs } from 'antd';
 import React, { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
+import { ProfileState } from 'src/ducks/profile/types';
+import { ApplicationPreference } from 'src/models/users';
 import styled from 'styled-components';
 
 import { MyPostsLocation, PostTabsType } from '../constants';
@@ -31,10 +34,20 @@ const TabbedPosts: React.FC = (): ReactElement => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   const { postType } = useParams() as Record<string, string>;
   const { t } = useTranslation();
+  const profileState = useSelector(
+    ({ profile }: { profile: ProfileState }) => profile,
+  );
 
-  function onChange(activeKey: string) {
+  // TODO: how to disable this warning? get error when I try
+  const onChange = (activeKey: string) => {
     history.replace(MyPostsLocation.toUrl({ postType: activeKey }));
-  }
+
+    if (profileState.profile) {
+      profileState.profile.applicationPreference =
+        activeKey === PostTabsType.requests ?
+        ApplicationPreference.pin : ApplicationPreference.cav;
+    }
+  };
 
   return (
     <StyledTabs activeKey={postType} onChange={onChange}>

--- a/web-client/src/modules/requests/pages/TabbedPostsPage.tsx
+++ b/web-client/src/modules/requests/pages/TabbedPostsPage.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 import { ProfileState } from 'src/ducks/profile/types';
-import { ApplicationPreference } from 'src/models/users';
 import styled from 'styled-components';
 
 import { MyPostsLocation, PostTabsType } from '../constants';
@@ -40,12 +39,10 @@ const TabbedPosts: React.FC = (): ReactElement => {
 
   // TODO: how to disable this warning? get error when I try
   const onChange = (activeKey: string) => {
-    history.replace(MyPostsLocation.toUrl({ postType: activeKey }));
-
+    const url = MyPostsLocation.toUrl({ postType: activeKey });
+    history.replace(url);
     if (profileState.profile) {
-      profileState.profile.applicationPreference =
-        activeKey === PostTabsType.requests ?
-        ApplicationPreference.pin : ApplicationPreference.cav;
+      profileState.profile.url = url;
     }
   };
 

--- a/web-client/src/modules/timeline/containers/TimelineViewContainer/TimelineViewContainer.tsx
+++ b/web-client/src/modules/timeline/containers/TimelineViewContainer/TimelineViewContainer.tsx
@@ -8,15 +8,15 @@ import { setOffer } from 'src/ducks/offers/actions';
 import { OffersState } from 'src/ducks/offers/types';
 import { ProfileState } from 'src/ducks/profile/types';
 import {
-  getAcceptedRequests,
+  getAcceptedPosts,
   getArchivedRequests,
   getFinishedRequests,
-  getOngoingRequests,
-  getOpenRequests,
+  getOngoingPosts,
+  getOpenPosts,
   resetSetRequestState,
   setRequest as updateRequest,
 } from 'src/ducks/requests/actions';
-import { RequestState } from 'src/ducks/requests/types';
+import { PostState } from 'src/ducks/requests/types';
 import { IOffer, OfferStatus } from 'src/models/offers';
 import { IRequest, RequestStatus } from 'src/models/requests';
 import { RequestWithOffersAndTimeline } from 'src/models/requests/RequestWithOffersAndTimeline';
@@ -66,7 +66,7 @@ const TimelineViewContainer: React.FC<TimelineViewContainerProps> = ({
   );
 
   const requestsState = useSelector(
-    ({ requests }: { requests: RequestState }) => requests,
+    ({ requests }: { requests: PostState }) => requests,
   );
 
   const offersState = useSelector(
@@ -90,15 +90,15 @@ const TimelineViewContainer: React.FC<TimelineViewContainerProps> = ({
 
   useEffect(() => {
     let requestTemp: RequestWithOffersAndTimeline | undefined =
-      requestsState.syncOpenRequestsState.data &&
-      requestsState.syncOpenRequestsState.data[requestId]
-        ? requestsState.syncOpenRequestsState.data[requestId]
+      requestsState.syncRequestPostsState.data &&
+      requestsState.syncRequestPostsState.data[requestId]
+        ? requestsState.syncRequestPostsState.data[requestId]
         : undefined;
     requestTemp =
       requestTemp ||
-      (requestsState.syncAcceptedRequestsState.data &&
-      requestsState.syncAcceptedRequestsState.data[requestId]
-        ? requestsState.syncAcceptedRequestsState.data[requestId]
+      (requestsState.syncOfferPostsState.data &&
+      requestsState.syncOfferPostsState.data[requestId]
+        ? requestsState.syncOfferPostsState.data[requestId]
         : undefined);
     requestTemp =
       requestTemp ||
@@ -157,11 +157,11 @@ const TimelineViewContainer: React.FC<TimelineViewContainerProps> = ({
         history.replace(TimelineViewLocation.toUrl({ requestId }));
       } else {
         if (
-          !requestsState.syncOpenRequestsState.data &&
-          !requestsState.syncOpenRequestsState.loading
+          !requestsState.syncRequestPostsState.data &&
+          !requestsState.syncRequestPostsState.loading
         ) {
           dispatch(
-            getOpenRequests({
+            getOpenPosts({
               userType: profileState.profile.applicationPreference,
               userRef: profileState.userRef,
               lat:
@@ -174,11 +174,11 @@ const TimelineViewContainer: React.FC<TimelineViewContainerProps> = ({
           );
         }
         if (
-          !requestsState.syncAcceptedRequestsState.data &&
-          !requestsState.syncAcceptedRequestsState.loading
+          !requestsState.syncOfferPostsState.data &&
+          !requestsState.syncOfferPostsState.loading
         ) {
           dispatch(
-            getAcceptedRequests({
+            getAcceptedPosts({
               userType: profileState.profile.applicationPreference,
               userRef: profileState.userRef,
             }),
@@ -189,7 +189,7 @@ const TimelineViewContainer: React.FC<TimelineViewContainerProps> = ({
           !requestsState.syncOngoingRequestsState.loading
         ) {
           dispatch(
-            getOngoingRequests({
+            getOngoingPosts({
               userType: profileState.profile.applicationPreference,
               userRef: profileState.userRef,
             }),


### PR DESCRIPTION
I would like to do more refactoring of this, including:
- fix unnecessary execution of request query when going to offers and vice versa
- get rid of PostsContainer.tsx
- possibly rename profileState to sessionState and profileState.profile to sessionState.user
- investigate using profileState.url instead, but I could not get this to work
- make code more understandable
- see if any duplicated code in OfferPostsContainer and ReqestPostsContainer can be combined without sacrificing readability of either
- add tests


If you don't see anything significantly wrong and you think this improves the code since it fixes a bug, can you merge?  I can make changes you want.