### PR TITLE
makes more space by removing title elements.  submitPost() occurs aft…

### DIFF
--- a/web-client/src/components/WebClientMap/WebClientMap.tsx
+++ b/web-client/src/components/WebClientMap/WebClientMap.tsx
@@ -7,7 +7,7 @@ import apiKey from './apiKey';
 import CustomMapControlPortal from './CustomMapControlPortal';
 import MyLocationControl from './MyLocationControl';
 import { metersToImperial, metersToKm, secondsToTimestring } from './utils';
-import { DestinationMarker, OriginMarker } from './WebClientMapMarker';
+import { DestinationMarker, SmallOrangeMarker } from './WebClientMapMarker';
 import WebClientMapMessage from './WebClientMapMessage';
 
 const createMapOptions = maps => ({
@@ -207,7 +207,7 @@ const WebClientMap: React.FC<MapProps> = ({
             <MyLocationControl onClick={locateMe} />
           </CustomMapControlPortal>
         )}
-        <OriginMarker lat={origin.lat} lng={origin.lng} isCav={isCav} />
+        <SmallOrangeMarker lat={origin.lat} lng={origin.lng} />
         {destinations.map(r => (
           <DestinationMarker
             key={r.id}

--- a/web-client/src/components/WebClientMap/WebClientMapMarker.tsx
+++ b/web-client/src/components/WebClientMap/WebClientMapMarker.tsx
@@ -1,10 +1,9 @@
 import { Coords } from 'google-map-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-
-import LargeOrangeMarkerIcon from './assets/map-marker-orange-lg.png';
-import SmallOrangeMarkerIcon from './assets/map-marker-orange-sm.png';
-import LargePurpleMarkerIcon from './assets/map-marker-purple-lg.png';
+import LargeOrangeMarkerIcon from 'src/components/WebClientMap/assets/map-marker-orange-lg.png';
+import SmallOrangeMarkerIcon from 'src/components/WebClientMap/assets/map-marker-orange-sm.png';
+import LargePurpleMarkerIcon from 'src/components/WebClientMap/assets/map-marker-purple-lg.png';
 
 export const OriginMarker: React.FC<OriginMarkerProps> = ({ isCav }) => {
   const { t } = useTranslation();
@@ -36,6 +35,20 @@ export const DestinationMarker: React.FC<DestinationMarkerProps> = ({
     </div>
   );
 };
+
+export const SmallOrangeMarker: React.FC<MarkerProps> = () => {
+  const { t } = useTranslation();
+  return (
+    <div style={{ transform: 'translate(-50%, -100%)' }}>
+      <img
+        src={SmallOrangeMarkerIcon}
+        alt={t('components.web_client_map.a11y_my_location')}
+      />
+    </div>
+  );
+};
+
+type MarkerProps = Coords;
 
 interface OriginMarkerProps extends Coords {
   isCav: boolean;

--- a/web-client/src/modules/create/components/DisplayElements.tsx
+++ b/web-client/src/modules/create/components/DisplayElements.tsx
@@ -37,7 +37,7 @@ export const AddressDisplay = ({ location, prefix }) => {
 
   return (
     <AddressDisplayWrapper>
-      <SectionLabel>
+      <SectionLabel role="heading">
         {prefix} {t('modules.create.stepTitles.map')}{' '}
       </SectionLabel>
       <Address>
@@ -91,7 +91,6 @@ export const MapDisplay = ({ coords }) => (
       <WebClientMap
         destinations={[]}
         zoom={17}
-        width="80%"
         height={mapHeight}
         origin={{ lat: coords.latitude, lng: coords.longitude }}
         canRelocate={false}

--- a/web-client/src/modules/create/components/DisplayElements.tsx
+++ b/web-client/src/modules/create/components/DisplayElements.tsx
@@ -9,23 +9,38 @@ const DetailsDisplayWrapper = styled.div`
 `;
 
 export const DetailsDisplay = ({ details }) => {
-  const { Paragraph, Title } = Typography;
+  const { Paragraph } = Typography;
   return (
     <DetailsDisplayWrapper>
-      <Title level={3}> {details.title} </Title>
+      <SectionLabel> {details.title} </SectionLabel>
       <Paragraph> {details.body} </Paragraph>
     </DetailsDisplayWrapper>
   );
 };
 
-export const AddressDisplay = ({ location }) => {
+const SectionLabel = styled.h1`
+  font: Roboto, sans-serif;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 32px;
+`;
+
+const Address = styled.address`
+  margin-left: 5px;
+  line-height: 22px;
+  font: Roboto, sans-serif;
+  font-size: 14px;
+`;
+
+export const AddressDisplay = ({ location, prefix }) => {
   const { t } = useTranslation();
-  const { Title } = Typography;
 
   return (
     <AddressDisplayWrapper>
-      <Title level={3}>{t('modules.create.displayElements.address')} </Title>
-      <address>
+      <SectionLabel>
+        {prefix} {t('modules.create.stepTitles.map')}{' '}
+      </SectionLabel>
+      <Address>
         {location.address1}
         <br />
         {location.address2}
@@ -34,7 +49,7 @@ export const AddressDisplay = ({ location }) => {
         {location.country}
         <br />
         {location.postalCode}
-      </address>
+      </Address>
     </AddressDisplayWrapper>
   );
 };
@@ -75,7 +90,8 @@ export const MapDisplay = ({ coords }) => (
     {coords && (
       <WebClientMap
         destinations={[]}
-        zoom={12}
+        zoom={17}
+        width="80%"
         height={mapHeight}
         origin={{ lat: coords.latitude, lng: coords.longitude }}
         canRelocate={false}

--- a/web-client/src/modules/create/components/PostDetailsStep.tsx
+++ b/web-client/src/modules/create/components/PostDetailsStep.tsx
@@ -2,12 +2,10 @@ import { ArrowRightOutlined, CloseOutlined } from '@ant-design/icons';
 import { Form, Input, Select } from 'antd';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import TitleWithUnderline from 'src/components/TitleWithUnderline/TitleWithUnderline';
 import {
   ButtonsDisplay,
   DisplayButton,
 } from 'src/modules/create/components/DisplayElements';
-import { COLORS } from 'src/theme/colors';
 import styled from 'styled-components';
 
 const PostDetails: React.FC<PostDetailsProps> = ({
@@ -16,7 +14,6 @@ const PostDetails: React.FC<PostDetailsProps> = ({
   postTypes,
   nextHandler,
   prevHandler,
-  postTypePrefix,
 }) => {
   const { t } = useTranslation();
   const [form] = Form.useForm();
@@ -30,9 +27,6 @@ const PostDetails: React.FC<PostDetailsProps> = ({
 
   return (
     <PostDetailsWrapper>
-      <TitleWithUnderline level={2} color={COLORS.primaryDark}>
-        {postTypePrefix} {t('modules.create.stepTitles.details')}
-      </TitleWithUnderline>
       <DetailsForm
         layout="vertical"
         form={form}

--- a/web-client/src/modules/create/components/PostLocationStep.tsx
+++ b/web-client/src/modules/create/components/PostLocationStep.tsx
@@ -2,7 +2,6 @@ import { ArrowLeftOutlined, ArrowRightOutlined } from '@ant-design/icons';
 import { Select } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import TitleWithUnderline from 'src/components/TitleWithUnderline/TitleWithUnderline';
 import { IUserAddress } from 'src/models/users/privilegedInformation';
 import {
   AddressDisplay,
@@ -11,7 +10,6 @@ import {
   DisplayButton,
   MapDisplay,
 } from 'src/modules/create/components/DisplayElements';
-import { COLORS } from 'src/theme/colors';
 import styled from 'styled-components';
 
 const PostLocationStep: React.FC<PostLocationStepProps> = ({
@@ -37,14 +35,10 @@ const PostLocationStep: React.FC<PostLocationStepProps> = ({
   return (
     <PostLocationWrapper>
       <MapDisplay coords={postLocation.coords} />
-      <TitleWithUnderline level={2} color={COLORS.primaryDark}>
-        {postTypePrefix} {t('modules.create.stepTitles.map')}
-      </TitleWithUnderline>
-      <LocationFormDiv>
-        <b>Choose an Address:</b>
+      <LocationForm>
         <ChooserDiv>
           <Select
-            style={{ width: 360 }}
+            style={{ width: '99%', margin: 'auto' }}
             onChange={handleAddressChange}
             defaultValue={postLocation.name}
           >
@@ -56,8 +50,8 @@ const PostLocationStep: React.FC<PostLocationStepProps> = ({
             <Select.Option value="add">Add a new one</Select.Option>
           </Select>
         </ChooserDiv>
-        <AddressDisplay location={postLocation} />
-      </LocationFormDiv>
+        <AddressDisplay prefix={postTypePrefix} location={postLocation} />
+      </LocationForm>
       <ButtonsContainer>
         <ButtonsDisplay>
           <DisplayButton
@@ -83,12 +77,13 @@ const PostLocationStep: React.FC<PostLocationStepProps> = ({
   );
 };
 
-const LocationFormDiv = styled.div`
+const LocationForm = styled.form`
   margin: 10px auto;
   width: 80%;
 `;
 const PostLocationWrapper = styled.div`
   height: 100%;
+  padding-left: 25px;
 `;
 
 const ChooserDiv = styled.div`

--- a/web-client/src/modules/create/components/PostSummaryStep.tsx
+++ b/web-client/src/modules/create/components/PostSummaryStep.tsx
@@ -2,7 +2,6 @@ import { ArrowLeftOutlined, StarOutlined } from '@ant-design/icons';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
-import TitleWithUnderline from 'src/components/TitleWithUnderline/TitleWithUnderline';
 import {
   AddressDisplay,
   ButtonsContainer,
@@ -28,17 +27,17 @@ const PostSummary: React.FC<PostSummaryProps> = ({
   const [showConfirmationPage, setShowConfirmationPage] = useState(false);
   const history = useHistory();
 
-  const handleSubmit = () => setShowConfirmationPage(true);
+  const handleSubmit = () => {
+    submitPost();
+    setShowConfirmationPage(true);
+  };
 
   return (
     <>
       <MapDisplay coords={coords} />
-      <TitleWithUnderline level={2} color={COLORS.primaryDark}>
-        {postTypePrefix} {t('modules.create.postSummary.confirmation')}{' '}
-      </TitleWithUnderline>
       <PostSummaryWrapper>
         <DetailsDisplay details={postDetails} />
-        <AddressDisplay location={postLocation} />
+        <AddressDisplay prefix={postTypePrefix} location={postLocation} />
       </PostSummaryWrapper>
       <ButtonsContainer>
         <ButtonsDisplay>
@@ -65,10 +64,8 @@ const PostSummary: React.FC<PostSummaryProps> = ({
         <PostConfirmation
           showModal={showConfirmationPage}
           closeModal={() => {
-            submitPost().then(() => {
-              history.replace(MyRequestPostsLocationUrl);
-            });
             setShowConfirmationPage(false);
+            history.replace(MyRequestPostsLocationUrl);
           }}
         />
       )}

--- a/web-client/src/modules/create/components/PostSummaryStep.tsx
+++ b/web-client/src/modules/create/components/PostSummaryStep.tsx
@@ -28,8 +28,14 @@ const PostSummary: React.FC<PostSummaryProps> = ({
   const history = useHistory();
 
   const handleSubmit = () => {
-    submitPost();
-    setShowConfirmationPage(true);
+    submitPost()
+      .then(() => {
+        setShowConfirmationPage(true);
+      })
+      .catch(() => {
+        // eslint-disable-next-line no-console
+        console.error('Could not submit new Post');
+      });
   };
 
   return (

--- a/web-client/src/modules/create/components/__tests/DisplayElements.test.tsx
+++ b/web-client/src/modules/create/components/__tests/DisplayElements.test.tsx
@@ -16,9 +16,9 @@ describe('AddressDisplay', () => {
       },
     };
 
-    const htmlElement = render(<AddressDisplay {...mockedProps} />).getByText(
-      'Address',
-    );
+    const htmlElement = render(
+      <AddressDisplay prefix="Offer" {...mockedProps} />,
+    ).getByRole('heading');
 
     expect(htmlElement).toBeInTheDocument();
   });


### PR DESCRIPTION
In order to create more space for the display elements, I have removed the Titles for each screen.  They are already given in the step-header.

submitPost() now occurs after the user presses the submit button.  Before it occured after closing the confirmation modal