### PR TITLE
Correct typo in color attribute

### DIFF
--- a/map/src/data/index.ts
+++ b/map/src/data/index.ts
@@ -8,26 +8,26 @@ export const SERVICES = {
     color: COLORS.orange,
   },
   beds: {
-    colors: COLORS.red,
+    color: COLORS.red,
   },
   oxygen: {
-    colors: COLORS.red,
+    color: COLORS.red,
   },
   medicine: {
     color: COLORS.purple,
   },
   'home-care': {
-    colors: COLORS.orange,
+    color: COLORS.orange,
   },
   blood: {
-    colors: COLORS.red,
+    color: COLORS.red,
   },
   quarantine: {
-    colors: COLORS.gray,
+    color: COLORS.gray,
   },
   telehealth: {
     // TODO: Might need to rename this?
-    colors: COLORS.blue,
+    color: COLORS.blue,
   },
   financial: {
     // TODO: rename to donations


### PR DESCRIPTION
## Description
Some selectors had "colors" instead of "color" as an attribute, deriving in those styles not being aplied.

## Motivation
Good first issues contributing, to learn and practice.

## Testing Guidelines
I haven't built the page and run it, so I don't know clearly which are the components affected by the styling.
But from the issue description, the oxygen, hospital and some other tags should be displaying the color specified for them.

## Release Checklist

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [x] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

closes #1337 

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
