### PR TITLE
#1203: add createdAt, updatedAt and verifiedAt

### DIFF
--- a/map/src/algolia-scripts/algoliaScriptHelper.mjs
+++ b/map/src/algolia-scripts/algoliaScriptHelper.mjs
@@ -63,6 +63,7 @@ export const processAlgolia = async (dataJSON, indexName, deleteAppendMode) => {
         marker.id = uuidv4();
       }
       marker.objectID = marker.id;
+      marker.createdAt = new Date();
     } else {
       throw new Error('One or more records are invalid.  Run validate script.');
     }

--- a/map/src/algoliaUtil.js
+++ b/map/src/algoliaUtil.js
@@ -63,6 +63,7 @@ export const processAlgolia = async (dataJSON, indexName, deleteAppendMode) => {
         marker.id = uuidv4();
       }
       marker.objectID = marker.id;
+      marker.createdAt = new Date();
     } else {
       throw new Error('One or more records are invalid.  Run validate script.');
     }

--- a/model/src/markers/index.ts
+++ b/model/src/markers/index.ts
@@ -82,6 +82,9 @@ export interface MarkerInfo<GeoPoint>
    */
   visible: boolean;
   objectID?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  verifiedAt?: Date;
   _geoLoc?: { lat: number; lng: number };
   source?: {
     name: 'hardcoded' | 'mutualaid.wiki' | 'mutualaidhub.org';


### PR DESCRIPTION
Fix #1203.

For the directories map and model:
1. Objects with objectID should also have createdAt, updatedAt and verifiedAt
2. Upon creating object with objectID, at createdAt with current Date
3. Don't change dataDriver.ts or JSON files