### PR TITLE
Add more test markers, fix some problems, add docs

### DIFF
--- a/map/src/algolia-scripts/json/markers-dev2.json
+++ b/map/src/algolia-scripts/json/markers-dev2.json
@@ -1,0 +1,382 @@
+[
+  {
+    "id": "good_id3",
+    "contact": {
+      "volunteers": {
+        "web": {
+          "Form": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform"
+        }
+      },
+      "getHelp": {
+        "web": {
+          "Form": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform"
+        }
+      }
+    },
+    "source": {
+      "id": "QZpBE4WPm7GvDH4lt0xs",
+      "name": "mutualaidhub.org",
+      "data": {
+        "address": "El Cerrito, CA 94530, USA",
+        "community": "",
+        "facebookPage": "",
+        "bbox": [
+          -122.323581,
+          37.897825,
+          -122.28108,
+          37.897825
+        ],
+        "country": "USA",
+        "language": [
+          "English",
+          "Spanish",
+          "Bangla"
+        ],
+        "lat": 37.9161326,
+        "supportRequestForm": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform",
+        "supportOfferForm": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform",
+        "title": "El Cerrito Mutual Aid Network",
+        "city": "El Cerrito",
+        "geocodeStatus": "",
+        "backendTags": [],
+        "hotlineNumber": "",
+        "displayFilterTags": [],
+        "state": "CA",
+        "neighborhood": "",
+        "generalForm": "",
+        "lng": -122.310765,
+        "zipCode": ""
+      }
+    },
+    "type": {
+      "type": "mutual-aid-group"
+    },
+    "loc": {
+      "latlng": {
+        "latitude": 37.9161326,
+        "longitude": -122.310765
+      },
+      "description": "El Cerrito, CA 94530, USA"
+    },
+    "visible": true,
+    "contentTitle": "El Cerrito Mutual Aid Network",
+    "objectID": "1272a4cf592b95_dashboard_generated_id"
+  },
+  {
+    "contentTitle": "Barrie Covid-19 Mutual Aid Group",
+    "type": {
+      "type": "mutual-aid-group",
+      "services": [
+        "food"
+      ]
+    },
+    "source": {
+      "data": {
+        "zipCode": "L4M 1K0",
+        "community": "",
+        "address": "301 Blake St, Barrie, ON L4M 1K0, Canada",
+        "city": "Barrie",
+        "state": "ON",
+        "facebookPage": "https://www.facebook.com/groups/BarrieCovid19MutualAidGroup/",
+        "bbox": [
+          -79.65910898029149,
+          44.39464101970849,
+          -79.65641101970849,
+          44.39464101970849
+        ],
+        "supportRequestForm": "",
+        "geocodeStatus": "",
+        "category": "Network",
+        "hotlineNumber": "",
+        "backendTags": [],
+        "generalForm": "",
+        "title": "Barrie Covid-19 Mutual Aid Group",
+        "lat": 44.39599,
+        "language": [
+          "English"
+        ],
+        "displayFilterTags": [],
+        "lng": -79.65776,
+        "country": "Canada",
+        "neighborhood": "",
+        "supportOfferForm": ""
+      },
+      "name": "mutualaidhub.org",
+      "id": "9kia6q4Qhf0PS53cy4yU"
+    },
+    "visible": true,
+    "loc": {
+      "description": "301 Blake St, Barrie, ON L4M 1K0, Canada",
+      "latlng": {
+        "latitude": 44.39599,
+        "longitude": -79.65776
+      }
+    },
+    "contact": {
+      "general": {
+        "web": {
+          "Facebook Page": "https://www.facebook.com/groups/BarrieCovid19MutualAidGroup/"
+        }
+      }
+    },
+    "id": "3Rcq4W1RUM4JrhYbc6un",
+    "objectID": "a4d1523ac49ee_dashboard_generated_id"
+  },
+  {
+    "id": "good_id4",
+    "contact": {
+      "volunteers": {
+        "web": {
+          "Form": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform"
+        }
+      },
+      "getHelp": {
+        "web": {
+          "Form": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform"
+        }
+      }
+    },
+    "source": {
+      "id": "QZpBE4WPm7GvDH4lt0xv",
+      "name": "mutualaidhub.org",
+      "data": {
+        "address": "Somewhere",
+        "community": "",
+        "facebookPage": "",
+        "bbox": [
+          -122.323581,
+          37.897825,
+          -122.28108,
+          37.897825
+        ],
+        "country": "USA",
+        "language": [
+          "English",
+          "Spanish",
+          "Bangla"
+        ],
+        "lat": 47.9161326,
+        "supportRequestForm": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform",
+        "supportOfferForm": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform",
+        "title": "Some Org",
+        "city": "Some City",
+        "geocodeStatus": "",
+        "backendTags": [],
+        "hotlineNumber": "",
+        "displayFilterTags": [],
+        "state": "CA",
+        "neighborhood": "",
+        "generalForm": "",
+        "lng": -112.310765,
+        "zipCode": ""
+      }
+    },
+    "type": {
+      "type": "org",
+      "services": [
+        "medicine"
+      ]
+    },
+    "loc": {
+      "latlng": {
+        "latitude": 47.9161326,
+        "longitude": -112.310765
+      },
+      "description": "Some address"
+    },
+    "visible": true,
+    "contentTitle": "Test Org",
+    "_geoloc": {
+      "lat": 47.9161326,
+      "lng": -112.310765
+    },
+    "createdAt": "2021-06-15T15:11:47.509Z",
+    "objectID": "good_id4"
+  },
+  {
+    "id": "good_id5",
+    "contact": {
+      "volunteers": {
+        "web": {
+          "Form": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform"
+        }
+      },
+      "getHelp": {
+        "web": {
+          "Form": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform"
+        }
+      }
+    },
+    "source": {
+      "id": "QZpBE4WPm7GvDH4lt0xw",
+      "name": "mutualaidhub.org",
+      "data": {
+        "address": "Somewhere",
+        "community": "",
+        "facebookPage": "",
+        "bbox": [
+          -132.323581,
+          27.897825,
+          -132.28108,
+          27.897825
+        ],
+        "country": "USA",
+        "language": [
+          "English",
+          "Spanish",
+          "Bangla"
+        ],
+        "lat": 27.9161326,
+        "supportRequestForm": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform",
+        "supportOfferForm": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform",
+        "title": "Some Hospital",
+        "city": "Some City",
+        "geocodeStatus": "",
+        "backendTags": [],
+        "hotlineNumber": "",
+        "displayFilterTags": [],
+        "state": "CA",
+        "neighborhood": "",
+        "generalForm": "",
+        "lng": -132.310765,
+        "zipCode": ""
+      }
+    },
+    "type": {
+      "type": "hospital",
+      "services": [
+        "medicine",
+        "home-care",
+        "blood",
+        "quarantine",
+        "telehealth"
+      ]
+    },
+    "loc": {
+      "latlng": {
+        "latitude": 27.9161326,
+        "longitude": -132.310765
+      },
+      "description": "Some address"
+    },
+    "visible": true,
+    "contentTitle": "Test Hospital",
+    "_geoloc": {
+      "lat": 27.9161326,
+      "lng": -132.310765
+    },
+    "createdAt": "2021-06-15T15:11:47.509Z",
+    "objectID": "good_id5"
+  },
+  {
+    "id": "good_id6",
+    "contact": {
+      "volunteers": {
+        "web": {
+          "Form": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform"
+        }
+      },
+      "getHelp": {
+        "web": {
+          "Form": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform"
+        }
+      }
+    },
+    "source": {
+      "id": "QZpBE4WPm7GvDH4lt0ys",
+      "name": "mutualaidhub.org",
+      "data": {
+        "address": "Some address",
+        "community": "",
+        "facebookPage": "",
+        "bbox": [
+          -122.323581,
+          37.897825,
+          -122.28108,
+          37.897825
+        ],
+        "country": "USA",
+        "language": [
+          "English",
+          "Spanish",
+          "Bangla"
+        ],
+        "lat": 50,
+        "supportRequestForm": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform",
+        "supportOfferForm": "https://docs.google.com/forms/d/e/1FAIpQLSf7xkSIiHpuq6lKG2r6C0-FnhpZH4JNe1xxsckDXLxu3eHJSQ/viewform",
+        "title": "Test Hidden Marker",
+        "city": "Test Hidden",
+        "geocodeStatus": "",
+        "backendTags": [],
+        "hotlineNumber": "",
+        "displayFilterTags": [],
+        "state": "CA",
+        "neighborhood": "",
+        "generalForm": "",
+        "lng": -120,
+        "zipCode": ""
+      }
+    },
+    "type": {
+      "type": "mutual-aid-group",
+      "services": [
+        "food",
+        "shelter",
+        "beds"
+      ],
+      "visible": false
+    },
+    "loc": {
+      "latlng": {
+        "latitude": 50,
+        "longitude": -120
+      },
+      "description": "Hidden Marker"
+    },
+    "contentTitle": "Test Hidden Marker 1",
+    "_geoloc": {
+      "lat": 50,
+      "lng": -120
+    },
+    "createdAt": "2021-06-15T15:11:47.509Z",
+    "visible": false,
+    "objectID": "good_id6"
+  },
+  {
+    "contentTitle": "Test Hidden Marker 2",
+    "type": {
+      "type": "company",
+      "services": [
+        "blood",
+        "quarantine"
+      ]
+    },
+    "loc": {
+      "description": "Somewhere",
+      "serviceRadius": 3390990.402572007,
+      "latlng": {
+        "latitude": 41.95195315673188,
+        "longitude": -86.53355625
+      }
+    },
+    "contact": {
+      "general": {
+        "email": [
+          "example@example.ca"
+        ],
+        "phone": [
+          "1111111111"
+        ]
+      }
+    },
+    "visible": false,
+    "_geoLoc": {
+      "lat": 41.95195315673188,
+      "lng": 41.95195315673188
+    },
+    "id": "MAH-a56f90c0-48a4-4868-95e8-c0622cd19e4f",
+    "createdAt": "2021-07-01T13:07:56.473Z",
+    "updatedAt": "2021-07-01T13:07:56.473Z",
+    "objectID": "MAH-a56f90c0-48a4-4868-95e8-c0622cd19e4f"
+  }
+]

--- a/map/src/components/drop-down.tsx
+++ b/map/src/components/drop-down.tsx
@@ -38,7 +38,7 @@ class DropDown extends React.Component<Props, {}> {
     translationObject: any,
     propKey: string,
     valueKey: string,
-  ): string => {
+  ): string | undefined => {
     let val = translationObject;
     const keys = propKey.split('.');
     keys.forEach(key => {
@@ -61,17 +61,30 @@ class DropDown extends React.Component<Props, {}> {
         value,
         {
           value,
-          label: t(lang, translationObject =>
-            this.lookUpValue(translationObject, translationKey, value),
+          label: t(
+            lang,
+            translationObject =>
+              this.lookUpValue(
+                translationObject,
+                translationKey,
+                value,
+              ) as string,
           ),
         },
       ]),
     );
 
-    // TODO: refactor .services
     const any: OptionType = {
       value: undefined,
-      label: t(lang, translationObject => translationObject.services.any),
+      label: t(lang, translationObject =>
+        this.lookUpValue(translationObject, translationKey, 'any')
+          ? (this.lookUpValue(
+              translationObject,
+              translationKey,
+              'any',
+            ) as string)
+          : translationObject.services.any,
+      ),
     };
 
     const options: OptionType[] = [any, ...optionsMap.values()];

--- a/map/src/components/drop-down.tsx
+++ b/map/src/components/drop-down.tsx
@@ -76,12 +76,9 @@ class DropDown extends React.Component<Props, {}> {
 
     const options: OptionType[] = [any, ...optionsMap.values()];
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const searchInOptions = (filterScreen: any) =>
-      filterScreen[filterScreenField];
     const value =
-      typeof searchInOptions !== 'undefined'
-        ? optionsMap.get(searchInOptions(filter))
+      typeof filter[filterScreenField as keyof Filter] !== 'undefined'
+        ? optionsMap.get(filter[filterScreenField as keyof Filter] as string)
         : undefined;
 
     return (

--- a/map/src/components/drop-down.tsx
+++ b/map/src/components/drop-down.tsx
@@ -12,6 +12,14 @@ type OptionType = {
   label: string;
 };
 
+/**
+ * @param className the class name
+ * @param translationKey a dot-separated list of keys used to index a translationObject generated from json
+ * @param filterScreenField the property of filter this drop-down updates
+ * @param dropDownValues the drop down values
+ * @param filter the filter applied to the map
+ * @param updateFilter a callback that updates filter
+ */
 interface Props {
   className?: string;
   translationKey: string;
@@ -32,8 +40,17 @@ class DropDown extends React.Component<Props, {}> {
     }
   };
 
+  /**
+   * Returns the translated word at translationObject.propKey.valueKey if it exists, else undefined.
+   * For example, translationObject.services.org returns "Organization" if the translationObject
+   * is in English.
+   *
+   * @param translationObject an object generated from a json translation file
+   * @param propKey a dot-separated list of keys used to index into the translationObject
+   * @param valueKey a dropDownValue
+   * @return the translated label if it exists, else undefined
+   */
   private lookUpValue = (
-    // TODO: add some docs
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     translationObject: any,
     propKey: string,


### PR DESCRIPTION
Added another json file with more test markers, including hidden markers, different organization types, and varying services offered.

Removed casting the filter to any in order to dynamically index into the filter with a string by casting filterScreenField as a key of Filter.
<img width="892" alt="image" src="https://user-images.githubusercontent.com/41408654/124372091-1dc9e180-dc56-11eb-98bb-641127a5ac04.png">

I could not fully refactor out the translationObject.services.any, since the organization markers do not have a translated label for any yet. Instead, I made translationObject.services.any the default option if translationObject[translationKey]['any'] is unavailable, and otherwise translationObject[translationKey]['any'] is used.
<img width="892" alt="image" src="https://user-images.githubusercontent.com/41408654/124372097-28847680-dc56-11eb-9b2b-2a43fed1dc43.png">

Added some javadocs for the more confusing parts of the code.