### PR TITLE
default color needed for information and financial markers

### DIFF
--- a/map/src/data/index.ts
+++ b/map/src/data/index.ts
@@ -84,12 +84,12 @@ export const MARKER_TYPES = {
   individual: {
     color: COLORS.green,
   },
-  // financial: {
-  //   color: COLORS.green,
-  // },
-  // information: {
-  //   color: COLORS.purple,
-  // },
+  financial: {
+    color: COLORS.yellow,
+  },
+  information: {
+    color: COLORS.orange,
+  },
   other: {
     color: COLORS.orange,
   },


### PR DESCRIPTION
## Description
Default colors for `information` can not be removed yet because we still have markers in the data set for information.  Leaving default color for `financial` in dataset in case there are also financial data.  

## Motivation
<img width="1010" alt="Screen Shot 2021-07-11 at 8 30 19 AM" src="https://user-images.githubusercontent.com/1453956/125196024-3d4ca580-e226-11eb-8a1e-7b595cf4c5ca.png">


![Screen Shot 2021-07-09 at 12 37 52 PM](https://user-images.githubusercontent.com/1453956/125196036-4473b380-e226-11eb-95f7-cb253965bdde.png)

## Testing Guidelines

## Release Checklist

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
