### PR TITLE
Add accordion to show organization results detail

### DIFF
--- a/map/src/App.tsx
+++ b/map/src/App.tsx
@@ -26,6 +26,7 @@ interface State {
   nextResults: ResultsSet | null;
   resultsOpen: boolean;
   selectedResult: MarkerIdAndInfo | null;
+  showResultDetails: boolean;
   updateResultsCallback: (() => void) | null;
   lang: i18n.Language;
   inFrame: boolean;
@@ -40,6 +41,7 @@ class App extends React.Component<Props, State> {
       results: null,
       nextResults: null,
       resultsOpen: false,
+      showResultDetails: false,
       selectedResult: null,
       updateResultsCallback: null,
       lang: i18n.getLanguage(),
@@ -68,8 +70,14 @@ class App extends React.Component<Props, State> {
     this.setState({ updateResultsCallback: callback });
   };
 
-  private setSelectedResult = (selectedResult: MarkerIdAndInfo | null) => {
-    this.setState({ selectedResult });
+  private setSelectedResult = (
+    selectedResult: MarkerIdAndInfo | null,
+    showDetails = false,
+  ) => {
+    this.setState({
+      selectedResult,
+      showResultDetails: showDetails,
+    });
   };
 
   private setNextResults = (nextResults: ResultsSet | null) => {
@@ -128,6 +136,7 @@ class App extends React.Component<Props, State> {
       results,
       nextResults,
       resultsOpen,
+      showResultDetails,
       selectedResult,
       page,
       lang,
@@ -181,6 +190,7 @@ class App extends React.Component<Props, State> {
                     setSelectedResult={this.setSelectedResult}
                     updateResults={this.updateResults}
                     showMoreResults={this.showMoreResults}
+                    showResultDetails={showResultDetails}
                   />
                 ),
               }}

--- a/map/src/App.tsx
+++ b/map/src/App.tsx
@@ -26,7 +26,7 @@ interface State {
   nextResults: ResultsSet | null;
   resultsOpen: boolean;
   selectedResult: MarkerIdAndInfo | null;
-  showResultDetails: boolean;
+  mapMarkerClicked: boolean;
   updateResultsCallback: (() => void) | null;
   lang: i18n.Language;
   inFrame: boolean;
@@ -41,7 +41,7 @@ class App extends React.Component<Props, State> {
       results: null,
       nextResults: null,
       resultsOpen: false,
-      showResultDetails: false,
+      mapMarkerClicked: false,
       selectedResult: null,
       updateResultsCallback: null,
       lang: i18n.getLanguage(),
@@ -72,11 +72,11 @@ class App extends React.Component<Props, State> {
 
   private setSelectedResult = (
     selectedResult: MarkerIdAndInfo | null,
-    showDetails = false,
+    markerClicked = false,
   ) => {
     this.setState({
       selectedResult,
-      showResultDetails: showDetails,
+      mapMarkerClicked: markerClicked,
     });
   };
 
@@ -136,7 +136,7 @@ class App extends React.Component<Props, State> {
       results,
       nextResults,
       resultsOpen,
-      showResultDetails,
+      mapMarkerClicked,
       selectedResult,
       page,
       lang,
@@ -190,7 +190,7 @@ class App extends React.Component<Props, State> {
                     setSelectedResult={this.setSelectedResult}
                     updateResults={this.updateResults}
                     showMoreResults={this.showMoreResults}
-                    showResultDetails={showResultDetails}
+                    mapMarkerClicked={mapMarkerClicked}
                   />
                 ),
               }}

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -78,7 +78,10 @@ interface Props {
   nextResults: ResultsSet | null;
   setNextResults: (nextResults: ResultsSet) => void;
   selectedResult: MarkerIdAndInfo | null;
-  setSelectedResult: (selectedResult: MarkerIdAndInfo | null) => void;
+  setSelectedResult: (
+    selectedResult: MarkerIdAndInfo | null,
+    showDetails?: boolean,
+  ) => void;
   /**
    * Call this
    */
@@ -358,7 +361,7 @@ class MapComponent extends React.Component<Props, State> {
       if (!this.mapClicked(event)) {
         const i = this.getMarkerInfo(marker);
         if (i) {
-          setSelectedResult(i);
+          setSelectedResult(i, true);
         }
       }
     });

--- a/map/src/components/map.tsx
+++ b/map/src/components/map.tsx
@@ -80,7 +80,7 @@ interface Props {
   selectedResult: MarkerIdAndInfo | null;
   setSelectedResult: (
     selectedResult: MarkerIdAndInfo | null,
-    showDetails?: boolean,
+    markerClicked?: boolean,
   ) => void;
   /**
    * Call this

--- a/map/src/components/resultDetail.tsx
+++ b/map/src/components/resultDetail.tsx
@@ -13,7 +13,7 @@ interface Props {
   fullDetail?: boolean;
 }
 
-const Div = styled('div')`
+const ResultDetailDiv = styled('div')`
   overflow-y: auto;
   max-height: 100%;
   background: #fff;
@@ -174,14 +174,14 @@ const contactInfo = (lang: Language, label: string, info?: ContactDetails) => {
 
 const ResultDetail = ({ result, lang, fullDetail = false }: Props) => {
   const selectedResultSource =
-    result?.info.source && SOURCES[result.info.source.name];
+    result.info.source && SOURCES[result.info.source.name];
   const selectedResultSentenceType =
-    result?.info.type.type === 'mutual-aid-group' ||
-    result?.info.type.type === 'org'
+    result.info.type.type === 'mutual-aid-group' ||
+    result.info.type.type === 'org'
       ? result.info.type.type
       : 'project';
   return (
-    <Div>
+    <ResultDetailDiv>
       <div className="disclaimer">
         <strong>{t(lang, s => s.results.details.disclaimer.header)}</strong>
         <br />
@@ -240,7 +240,7 @@ const ResultDetail = ({ result, lang, fullDetail = false }: Props) => {
           )}
         </div>
       )}
-    </Div>
+    </ResultDetailDiv>
   );
 };
 

--- a/map/src/components/resultDetail.tsx
+++ b/map/src/components/resultDetail.tsx
@@ -1,0 +1,247 @@
+import { ContactDetails } from '@reach4help/model/lib/markers';
+import React from 'react';
+import { MdEmail, MdLanguage, MdPhone } from 'react-icons/md';
+import { MarkerIdAndInfo } from 'src/components/map';
+import { Language, t } from 'src/i18n';
+
+import styled from '../styling';
+import MarkerType from './marker-type';
+
+interface Props {
+  result: MarkerIdAndInfo;
+  lang: Language;
+  fullDetail?: boolean;
+}
+
+const Div = styled('div')`
+  overflow-y: auto;
+  max-height: 100%;
+  background: #fff;
+  padding: ${p => p.theme.spacingPx}px;
+  overflow-y: auto;
+  background: #fff;
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.15);
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  cursor: auto;
+  pointer-events: initial;
+
+  > .disclaimer,
+  > .source {
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 3px;
+    padding: 10px 8px;
+    color: rgba(0, 0, 0, 0.5);
+    margin-bottom: 20px;
+
+    strong {
+      text-transform: uppercase;
+    }
+  }
+
+  > .disclaimer {
+    font-size: 10px;
+    line-height: 16px;
+  }
+
+  > .source {
+    font-size: 12px;
+    line-height: 150%;
+  }
+
+  > .name {
+    font-size: 1.5rem;
+    padding-bottom: ${p => p.theme.spacingPx / 2}px;
+  }
+
+  > .location {
+    color: ${p => p.theme.textColorLight};
+    font-size: 0.9rem;
+  }
+
+  > .marker-type {
+    margin-bottom: ${p => p.theme.spacingPx / 2}px;
+  }
+
+  > .contact-group {
+    margin-top: ${p => p.theme.spacingPx}px;
+    color: ${p => p.theme.textColorLight};
+
+    ul {
+      padding-left: ${p => p.theme.spacingPx}px;
+      margin-left: ${p => p.theme.spacingPx}px;
+      a {
+        display: inline-flex;
+        align-items: center;
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
+        }
+
+        svg {
+          margin-right: ${p => p.theme.spacingPx / 2}px;
+        }
+      }
+    }
+  }
+`;
+
+const SOURCES = {
+  'mutualaid.wiki': {
+    label: 'Mutual Aid Wiki',
+    href: 'https://mutualaid.wiki/',
+  },
+  'mutualaidhub.org': {
+    label: 'Mutual Aid Hub',
+    href: 'https://www.mutualaidhub.org/',
+  },
+  hardcoded: null,
+};
+
+const contactInfo = (lang: Language, label: string, info?: ContactDetails) => {
+  if (!info) {
+    return null;
+  }
+  const items: Array<JSX.Element> = [];
+  if (info.phone) {
+    items.push(
+      ...info.phone.map(number => (
+        <a key={items.length} href={`tel:${number.replace(/\s/g, '')}`}>
+          <MdPhone />
+          {number}
+        </a>
+      )),
+    );
+  }
+  if (info.email) {
+    items.push(
+      ...info.email.map(email => (
+        <a
+          key={items.length}
+          href={`mailto:${email}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <MdEmail />
+          {email}
+        </a>
+      )),
+    );
+  }
+  if (info.facebookGroup) {
+    items.push(
+      <a
+        key={items.length}
+        href={info.facebookGroup}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <MdLanguage />
+        {t(lang, s => s.results.contact.facebookGroup)}
+      </a>,
+    );
+  }
+  if (info.web) {
+    items.push(
+      ...Object.entries(info.web).map(entry => (
+        <a
+          key={items.length}
+          href={entry[1]}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <MdLanguage />
+          {entry[0]}
+        </a>
+      )),
+    );
+  }
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <div className="contact-group">
+      <strong>{label}</strong>
+      <ul>
+        {items.map((item, i) => (
+          <li key={i}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+const ResultDetail = ({ result, lang, fullDetail = false }: Props) => {
+  const selectedResultSource =
+    result?.info.source && SOURCES[result.info.source.name];
+  const selectedResultSentenceType =
+    result?.info.type.type === 'mutual-aid-group' ||
+    result?.info.type.type === 'org'
+      ? result.info.type.type
+      : 'project';
+  return (
+    <Div>
+      <div className="disclaimer">
+        <strong>{t(lang, s => s.results.details.disclaimer.header)}</strong>
+        <br />
+        {t(lang, s => s.results.details.disclaimer.content)}
+      </div>
+
+      {fullDetail && <div className="name">{result.info.contentTitle}</div>}
+      {fullDetail && result.info.loc.description && (
+        <div className="location">{result.info.loc.description}</div>
+      )}
+      {fullDetail && (
+        <MarkerType className="marker-type" type={result.info.type} />
+      )}
+      {selectedResultSource && (
+        <div className="source">
+          {t(lang, s => s.results.details.source, {
+            type: key => (
+              <span key={key}>
+                {t(lang, s => s.markerTypeSentence[selectedResultSentenceType])}
+              </span>
+            ),
+            source: key => (
+              <a
+                key={key}
+                href={selectedResultSource.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {selectedResultSource.label}
+              </a>
+            ),
+          })}
+        </div>
+      )}
+      {result.info.contentBody && (
+        <div>
+          <div className="content">{result.info.contentBody}</div>
+        </div>
+      )}
+      {result.info.contact && (
+        <div>
+          {contactInfo(
+            lang,
+            t(lang, s => s.results.contact.general),
+            result.info.contact.general,
+          )}
+          {contactInfo(
+            lang,
+            t(lang, s => s.results.contact.getHelp),
+            result.info.contact.getHelp,
+          )}
+          {contactInfo(
+            lang,
+            t(lang, s => s.results.contact.volunteer),
+            result.info.contact.volunteers,
+          )}
+        </div>
+      )}
+    </Div>
+  );
+};
+
+export default ResultDetail;

--- a/map/src/components/results.tsx
+++ b/map/src/components/results.tsx
@@ -1,15 +1,15 @@
-import { ContactDetails } from '@reach4help/model/lib/markers';
 import isEqual from 'lodash/isEqual';
 import React from 'react';
-import { MdEmail, MdExpandMore, MdLanguage, MdPhone } from 'react-icons/md';
+import { MdExpandMore } from 'react-icons/md';
 import Chevron from 'src/components/assets/chevron';
 import Refresh from 'src/components/assets/refresh';
 import { MarkerIdAndInfo, ResultsSet } from 'src/components/map';
-import { format, Language, t } from 'src/i18n';
+import { format, t } from 'src/i18n';
 
 import styled from '../styling';
 import { AppContext } from './context';
 import MarkerType from './marker-type';
+import ResultDetail from './resultDetail';
 
 interface Props {
   className?: string;
@@ -23,93 +23,9 @@ interface Props {
   setSelectedResult: (selectedResult: MarkerIdAndInfo | null) => void;
   showMoreResults: (count: number) => void;
 }
-const SOURCES = {
-  'mutualaid.wiki': {
-    label: 'Mutual Aid Wiki',
-    href: 'https://mutualaid.wiki/',
-  },
-  'mutualaidhub.org': {
-    label: 'Mutual Aid Hub',
-    href: 'https://www.mutualaidhub.org/',
-  },
-  hardcoded: null,
-};
-
-const contactInfo = (lang: Language, label: string, info?: ContactDetails) => {
-  if (!info) {
-    return null;
-  }
-  const items: Array<JSX.Element> = [];
-  if (info.phone) {
-    items.push(
-      ...info.phone.map(number => (
-        <a key={items.length} href={`tel:${number.replace(/\s/g, '')}`}>
-          <MdPhone />
-          {number}
-        </a>
-      )),
-    );
-  }
-  if (info.email) {
-    items.push(
-      ...info.email.map(email => (
-        <a
-          key={items.length}
-          href={`mailto:${email}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <MdEmail />
-          {email}
-        </a>
-      )),
-    );
-  }
-  if (info.facebookGroup) {
-    items.push(
-      <a
-        key={items.length}
-        href={info.facebookGroup}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <MdLanguage />
-        {t(lang, s => s.results.contact.facebookGroup)}
-      </a>,
-    );
-  }
-  if (info.web) {
-    items.push(
-      ...Object.entries(info.web).map(entry => (
-        <a
-          key={items.length}
-          href={entry[1]}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <MdLanguage />
-          {entry[0]}
-        </a>
-      )),
-    );
-  }
-  if (items.length === 0) {
-    return null;
-  }
-  return (
-    <div className="contact-group">
-      <strong>{label}</strong>
-      <ul>
-        {items.map((item, i) => (
-          <li key={i}>{item}</li>
-        ))}
-      </ul>
-    </div>
-  );
-};
 
 class Results extends React.PureComponent<Props, { expandResult: boolean }> {
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
     this.state = { expandResult: false };
   }
@@ -147,13 +63,6 @@ class Results extends React.PureComponent<Props, { expandResult: boolean }> {
     const canUpdateResults =
       !isEqual(results?.context, nextResults?.context) ||
       !isEqual(results?.results, nextResults?.results);
-    const selectedResultSource =
-      selectedResult?.info.source && SOURCES[selectedResult.info.source.name];
-    const selectedResultSentenceType =
-      selectedResult?.info.type.type === 'mutual-aid-group' ||
-      selectedResult?.info.type.type === 'org'
-        ? selectedResult.info.type.type
-        : 'project';
     return (
       <AppContext.Consumer>
         {({ lang }) => (
@@ -198,14 +107,13 @@ class Results extends React.PureComponent<Props, { expandResult: boolean }> {
                 {(results?.results || [])
                   .slice(0, results?.showRows)
                   .map((result, index) => (
-                    <div
-                      key={index}
-                      className="result"
-                      onClick={() => {
-                        this.resultClicked(result);
-                      }}
-                    >
-                      <div className="flexContainer">
+                    <div key={index} className="result">
+                      <div
+                        className="flexContainer"
+                        onClick={() => {
+                          this.resultClicked(result);
+                        }}
+                      >
                         <div className="resultItem">
                           <div className="number">{index + 1}</div>
                           <div className="info">
@@ -229,71 +137,7 @@ class Results extends React.PureComponent<Props, { expandResult: boolean }> {
                         />
                       </div>
                       {selectedResult?.id === result.id && expandResult && (
-                        <div className="details preview">
-                          <div className="disclaimer">
-                            <strong>
-                              {t(
-                                lang,
-                                s => s.results.details.disclaimer.header,
-                              )}
-                            </strong>
-                            <br />
-                            {t(lang, s => s.results.details.disclaimer.content)}
-                          </div>
-                          {selectedResultSource && (
-                            <div className="source">
-                              {t(lang, s => s.results.details.source, {
-                                type: key => (
-                                  <span key={key}>
-                                    {t(
-                                      lang,
-                                      s =>
-                                        s.markerTypeSentence[
-                                          selectedResultSentenceType
-                                        ],
-                                    )}
-                                  </span>
-                                ),
-                                source: key => (
-                                  <a
-                                    key={key}
-                                    href={selectedResultSource.href}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                  >
-                                    {selectedResultSource.label}
-                                  </a>
-                                ),
-                              })}
-                            </div>
-                          )}
-                          {result.info.contentBody && (
-                            <div>
-                              <div className="content">
-                                {result.info.contentBody}
-                              </div>
-                            </div>
-                          )}
-                          {result.info.contact && (
-                            <div>
-                              {contactInfo(
-                                lang,
-                                t(lang, s => s.results.contact.general),
-                                result.info.contact.general,
-                              )}
-                              {contactInfo(
-                                lang,
-                                t(lang, s => s.results.contact.getHelp),
-                                result.info.contact.getHelp,
-                              )}
-                              {contactInfo(
-                                lang,
-                                t(lang, s => s.results.contact.volunteer),
-                                result.info.contact.volunteers,
-                              )}
-                            </div>
-                          )}
-                        </div>
+                        <ResultDetail result={selectedResult} lang={lang} />
                       )}
                     </div>
                   ))}
@@ -314,78 +158,7 @@ class Results extends React.PureComponent<Props, { expandResult: boolean }> {
                   <div className="details">Data loading. Try again later.</div>
                 )}
               {selectedResult && (
-                <div className="details">
-                  <div className="disclaimer">
-                    <strong>
-                      {t(lang, s => s.results.details.disclaimer.header)}
-                    </strong>
-                    <br />
-                    {t(lang, s => s.results.details.disclaimer.content)}
-                  </div>
-                  <div className="name">{selectedResult.info.contentTitle}</div>
-                  {selectedResult.info.loc.description && (
-                    <div className="location">
-                      {selectedResult.info.loc.description}
-                    </div>
-                  )}
-                  <MarkerType
-                    className="marker-type"
-                    type={selectedResult.info.type}
-                  />
-                  {selectedResultSource && (
-                    <div className="source">
-                      {t(lang, s => s.results.details.source, {
-                        type: key => (
-                          <span key={key}>
-                            {t(
-                              lang,
-                              s =>
-                                s.markerTypeSentence[
-                                  selectedResultSentenceType
-                                ],
-                            )}
-                          </span>
-                        ),
-                        source: key => (
-                          <a
-                            key={key}
-                            href={selectedResultSource.href}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            {selectedResultSource.label}
-                          </a>
-                        ),
-                      })}
-                    </div>
-                  )}
-                  {selectedResult.info.contentBody && (
-                    <div>
-                      <div className="content">
-                        {selectedResult.info.contentBody}
-                      </div>
-                    </div>
-                  )}
-                  {selectedResult.info.contact && (
-                    <div>
-                      {contactInfo(
-                        lang,
-                        t(lang, s => s.results.contact.general),
-                        selectedResult.info.contact.general,
-                      )}
-                      {contactInfo(
-                        lang,
-                        t(lang, s => s.results.contact.getHelp),
-                        selectedResult.info.contact.getHelp,
-                      )}
-                      {contactInfo(
-                        lang,
-                        t(lang, s => s.results.contact.volunteer),
-                        selectedResult.info.contact.volunteers,
-                      )}
-                    </div>
-                  )}
-                </div>
+                <ResultDetail result={selectedResult} lang={lang} fullDetail />
               )}
             </div>
           </div>
@@ -511,8 +284,6 @@ export default styled(Results)`
         color: ${p => p.theme.textColor};
         border-bottom: ${p => p.theme.borderLight};
         padding: ${p => p.theme.spacingPx}px;
-        /* display: flex; */
-        /* align-items: start; */
         font-size: 1rem;
         cursor: pointer;
         &:hover {
@@ -522,16 +293,12 @@ export default styled(Results)`
           display: flex;
           justify-content: space-between;
 
-          .resultItem {
+          > .resultItem {
             display: flex;
             align-items: start;
             padding: ${p => p.theme.spacingPx}px;
 
-            .location {
-              color: ${p => p.theme.textColorLight};
-            }
-
-            .number {
+            > .number {
               color: ${p => p.theme.textColor};
               font-size: 20px;
               font-weight: 600;
@@ -561,7 +328,7 @@ export default styled(Results)`
       }
     }
 
-    .details {
+    > .details {
       overflow-y: auto;
       max-height: 100%;
       background: #fff;
@@ -572,70 +339,6 @@ export default styled(Results)`
       border-bottom-left-radius: 4px;
       border-bottom-right-radius: 4px;
       pointer-events: initial;
-
-      /* &.preview {
-        padding: 0;
-      } */
-
-      > .disclaimer,
-      > .source {
-        background: rgba(0, 0, 0, 0.05);
-        border-radius: 3px;
-        padding: 10px 8px;
-        color: rgba(0, 0, 0, 0.5);
-        margin-bottom: 20px;
-
-        strong {
-          text-transform: uppercase;
-        }
-      }
-
-      > .disclaimer {
-        font-size: 10px;
-        line-height: 16px;
-      }
-
-      > .source {
-        font-size: 12px;
-        line-height: 150%;
-      }
-
-      > .name {
-        font-size: 1.5rem;
-        padding-bottom: ${p => p.theme.spacingPx / 2}px;
-      }
-
-      > .location {
-        color: ${p => p.theme.textColorLight};
-        font-size: 0.9rem;
-      }
-
-      > .marker-type {
-        margin-bottom: ${p => p.theme.spacingPx / 2}px;
-      }
-
-      > .contact-group {
-        margin-top: ${p => p.theme.spacingPx}px;
-        color: ${p => p.theme.textColorLight};
-
-        ul {
-          padding-left: ${p => p.theme.spacingPx}px;
-          margin-left: ${p => p.theme.spacingPx}px;
-          a {
-            display: inline-flex;
-            align-items: center;
-            text-decoration: none;
-
-            &:hover {
-              text-decoration: underline;
-            }
-
-            svg {
-              margin-right: ${p => p.theme.spacingPx / 2}px;
-            }
-          }
-        }
-      }
     }
   }
 

--- a/map/src/components/results.tsx
+++ b/map/src/components/results.tsx
@@ -18,16 +18,16 @@ interface Props {
   updateResults: () => void;
   open: boolean;
   setOpen: (open: boolean) => void;
-  showResultDetails: boolean;
+  mapMarkerClicked: boolean;
   selectedResult: MarkerIdAndInfo | null;
   setSelectedResult: (selectedResult: MarkerIdAndInfo | null) => void;
   showMoreResults: (count: number) => void;
 }
 
-class Results extends React.PureComponent<Props, { expandResult: boolean }> {
+class Results extends React.PureComponent<Props, { expandAccordion: boolean }> {
   constructor(props: Props) {
     super(props);
-    this.state = { expandResult: false };
+    this.state = { expandAccordion: false };
   }
 
   private headerClicked = () => {
@@ -41,22 +41,24 @@ class Results extends React.PureComponent<Props, { expandResult: boolean }> {
   };
 
   private resultClicked = (result: MarkerIdAndInfo | null) => {
-    const { expandResult } = this.state;
     const { selectedResult, setSelectedResult } = this.props;
-    const show = result?.id === selectedResult?.id ? !expandResult : true;
-    this.setState({ expandResult: show });
+    this.setState(state => {
+      const expand =
+        result?.id === selectedResult?.id ? !state.expandAccordion : true;
+      return { expandAccordion: expand };
+    });
     setSelectedResult(result);
   };
 
   public render() {
-    const { expandResult } = this.state;
+    const { expandAccordion } = this.state;
     const {
       className,
       results,
       nextResults,
       updateResults,
       open,
-      showResultDetails,
+      mapMarkerClicked,
       selectedResult,
       showMoreResults,
     } = this.props;
@@ -68,7 +70,7 @@ class Results extends React.PureComponent<Props, { expandResult: boolean }> {
         {({ lang }) => (
           <div
             className={`${className} ${open ? 'open' : ''} ${
-              selectedResult && showResultDetails ? 'selected-result' : ''
+              selectedResult && mapMarkerClicked ? 'selected-result' : ''
             }`}
           >
             <button
@@ -81,7 +83,7 @@ class Results extends React.PureComponent<Props, { expandResult: boolean }> {
                 {format(
                   lang,
                   s =>
-                    selectedResult && showResultDetails
+                    selectedResult && mapMarkerClicked
                       ? s.results.backToResults
                       : open
                       ? s.results.closeResults
@@ -130,13 +132,13 @@ class Results extends React.PureComponent<Props, { expandResult: boolean }> {
                         </div>
                         <Chevron
                           className={`${'toggle chevron'} ${
-                            selectedResult?.id === result.id && expandResult
+                            selectedResult?.id === result.id && expandAccordion
                               ? 'open'
                               : ''
                           }`}
                         />
                       </div>
-                      {selectedResult?.id === result.id && expandResult && (
+                      {selectedResult?.id === result.id && expandAccordion && (
                         <ResultDetail result={selectedResult} lang={lang} />
                       )}
                     </div>
@@ -151,7 +153,7 @@ class Results extends React.PureComponent<Props, { expandResult: boolean }> {
                   </div>
                 )}
               </div>
-              {showResultDetails &&
+              {mapMarkerClicked &&
                 selectedResult &&
                 !selectedResult?.info.contentBody &&
                 !selectedResult?.info.contact && (


### PR DESCRIPTION
## Description
This PR adds accordion to the organization search results and will show the details of the organization upon expanding. Previously, clicking an organization would show the details in a new view. Now it will appear right below the name of the organization.

The result details will still be shown in a new view if the organization markers are directly clicked on the map. 

## Motivation
Improve user experience

## Testing Guidelines

## Release Checklist

- [ ] This code has unit tests
- [ ] I have a plan to verify that these changes are working as expected after deploy
- [ ] I have a plan for how to revert, rollback, or disable these changes if things are not working as expected

## Security Checklist

This PR creates, modifies, or deletes:

- [ ] API routes: API routes, parameters, or user authorization
- [ ] Authentication: Authentication mechanism
- [ ] Credentials: Server side credentials, or secrets in configuration / source code
- [ ] Cryptography: Encryption, hashing, certificates, signatures, random numbers, etc.
- [ ] User data: personal information handling, logs, error messages, etc.

<!--

If you checked any of those, please request a review from `@reach4help/security`.

-->

## Additional Notes
**Before clicking**
![image](https://user-images.githubusercontent.com/52301822/161119410-33b949db-3cbd-4338-8c3b-42738ec7cf92.png)

**After clicking**
![image](https://user-images.githubusercontent.com/52301822/161119266-89c4fcf1-b185-4686-b950-893a594f78ca.png)

**When the map marker is directly clicked**
![image](https://user-images.githubusercontent.com/52301822/161119787-ce5d522b-b6e2-4285-90bd-a2be2d663512.png)

<!--

If this PR fixes an issue, please add "closes #issue-id" here, otherwise add a reference to the issue it relates to.

If this PR adds or changes visual, please add a screenshot of the changes.

-->
